### PR TITLE
feat: autoreason LLM-driven autonomous loop (issue #11, closes #10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ research_loop/tournament_results_v2.tsv
 workspace/
 RADIO/
 dino_finetune/output/
+
+# Reference material — NousResearch/autoreason repo + paper PDFs, used as
+# inspiration for research_loop's design but not part of this codebase.
+autoreason/

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -170,6 +170,26 @@ Epoch 30/30 | loss=... distill=... arc=... cosine=...
 V2 TRAINING COMPLETE
 ```
 
+### 2d. Real-LLM smoke (T8 — pre-flight before launching autoreason)
+
+Before kicking off a multi-hour autoreason run, verify the LLM round-trip works against your `ANTHROPIC_API_KEY`. This costs ~$0.05 (3 Sonnet 4.6 calls), takes ~30 seconds, and never touches the GPU:
+
+```bash
+ANTHROPIC_API_KEY=sk-... .venv/bin/python -m research_loop.tools.autoreason_smoke
+```
+
+What it verifies:
+
+- API key is reachable (env or `~/.hermes/.env`)
+- Critic returns a parseable Critique with a non-empty summary
+- Author B's diff passes `git apply --check` (or returns NO_PATCH)
+- Synthesizer's diff passes `git apply --check` (or returns NO_PATCH)
+- Working tree is unchanged after the smoke (`git apply --check` only, never applied)
+
+Run this once before any production `tournament autoreason` invocation. If the smoke fails, the autoreason loop will fail in the same place — but on a 10-hour run instead of 30 seconds.
+
+> **T8 status**: smoke script delivered (`research_loop/tools/autoreason_smoke.py`). The dev environment that built this PR has Claude Code OAuth but no raw `ANTHROPIC_API_KEY` exposed to the shell, so the manual verification has been deferred to the operator who launches the production run. Re-record the smoke output here once executed.
+
 ### 3. After the run — export ONNX + log to results_v2.tsv
 
 ```bash

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -170,25 +170,57 @@ Epoch 30/30 | loss=... distill=... arc=... cosine=...
 V2 TRAINING COMPLETE
 ```
 
-### 2d. Real-LLM smoke (T8 — pre-flight before launching autoreason)
+### 2d. LLM CLI selection
 
-Before kicking off a multi-hour autoreason run, verify the LLM round-trip works against your `ANTHROPIC_API_KEY`. This costs ~$0.05 (3 Sonnet 4.6 calls), takes ~30 seconds, and never touches the GPU:
+Per project decision, autoreason calls a local CLI (`hermes`, `claude`, or `codex`) — not raw API keys. Auth, rate limits, model selection, and provider routing all live in your already-configured tool.
+
+| CLI | Selection | Model passthrough |
+|---|---|---|
+| `hermes` *(default)* | `--llm-cli hermes` | `-m anthropic/claude-sonnet-4` (or any `provider/model` string Hermes accepts) |
+| `claude` | `--llm-cli claude` | `--model claude-sonnet-4-6` |
+| `codex` | `--llm-cli codex` | `--model gpt-5` (passed via `codex exec -c model=...`) |
+
+Selection order: explicit `--llm-cli` flag → `AUTORESEARCH_LLM_CLI` env var → default `hermes`.
 
 ```bash
-ANTHROPIC_API_KEY=sk-... .venv/bin/python -m research_loop.tools.autoreason_smoke
+# default (hermes, auto-pick provider)
+.venv/bin/python -m research_loop.tournament autoreason --target student_v2 --max-passes 1 --dry-run
+
+# claude with a specific model
+.venv/bin/python -m research_loop.tournament autoreason \
+    --target student_v2 --max-passes 1 --dry-run \
+    --llm-cli claude --llm-model claude-sonnet-4-6
+
+# codex
+.venv/bin/python -m research_loop.tournament autoreason \
+    --target student_v2 --max-passes 1 --dry-run \
+    --llm-cli codex
+```
+
+### 2e. Real-LLM smoke (T8 — pre-flight before launching autoreason)
+
+Before kicking off a multi-hour autoreason run, verify the round-trip via the chosen CLI. ~30 seconds, ~3 CLI invocations:
+
+```bash
+# default hermes
+.venv/bin/python -m research_loop.tools.autoreason_smoke
+
+# claude
+.venv/bin/python -m research_loop.tools.autoreason_smoke --llm-cli claude --llm-model claude-sonnet-4-6
+
+# codex
+.venv/bin/python -m research_loop.tools.autoreason_smoke --llm-cli codex
 ```
 
 What it verifies:
 
-- API key is reachable (env or `~/.hermes/.env`)
+- The selected CLI is callable and returns text
 - Critic returns a parseable Critique with a non-empty summary
 - Author B's diff passes `git apply --check` (or returns NO_PATCH)
 - Synthesizer's diff passes `git apply --check` (or returns NO_PATCH)
 - Working tree is unchanged after the smoke (`git apply --check` only, never applied)
 
-Run this once before any production `tournament autoreason` invocation. If the smoke fails, the autoreason loop will fail in the same place — but on a 10-hour run instead of 30 seconds.
-
-> **T8 status**: smoke script delivered (`research_loop/tools/autoreason_smoke.py`). The dev environment that built this PR has Claude Code OAuth but no raw `ANTHROPIC_API_KEY` exposed to the shell, so the manual verification has been deferred to the operator who launches the production run. Re-record the smoke output here once executed.
+Run this before any production `tournament autoreason` invocation. If the smoke fails, the autoreason loop will fail in the same place — but on a 10-hour run instead of 30 seconds.
 
 ### 3. After the run — export ONNX + log to results_v2.tsv
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -79,49 +79,78 @@ The file `student_finetune/productness_val_paths.txt` is gitignored. Regenerate 
 # expect: ~45k holdout paths from 450k total (10%)
 ```
 
-### 2. Train V2 via the research_loop tournament (issue #4 main flow)
+### 2. Train V2 via fully-autonomous `tournament autoreason` (recommended)
 
-The training driver is the autoreason tournament — every run is structured as a tournament round (A=incumbent, B/AB=experiments). The first production run is the seed: a "baseline-only" round with kind=A, no patch — establishes the row in `results_v2.tsv` that all future rounds challenge.
+The driver is the **autoreason loop** — Critic + Author B + Synthesizer LLM agents propose patches each pass, the adapter trains them under a per-candidate time budget, `promote.decide()` picks a winner via objective metrics, and the loop terminates when the incumbent wins `k` consecutive rounds. Zero human intervention between passes.
 
 ```bash
-# Stage 1 — DINOv3 teacher production baseline (~50h on 4090)
-nohup ../.venv/bin/python -u -m research_loop.tournament run-round \
-    --target dino_v2 \
-    --hypothesis "v2 teacher production baseline (productness ON, smoothing+focal)" \
-    --baseline-only \
-    > dino_finetune/run_v2_production.log 2>&1 &
+# Pre-flight: validate end-to-end with mocked subprocess (no GPU)
+.venv/bin/python -m research_loop.tournament autoreason \
+    --target student_v2 --max-passes 1 --dry-run
 
-# Stage 2 — LCNet student production baseline (~6-7h)
-nohup ../.venv/bin/python -u -m research_loop.tournament run-round \
+# Real run on student_v2 (productness ON; ~6-7h × per-candidate budget)
+nohup .venv/bin/python -u -m research_loop.tournament autoreason \
     --target student_v2 \
-    --hypothesis "v2 student production baseline (productness ON, smoothing+focal)" \
-    --baseline-only \
+    --max-passes 15 \
+    --convergence 2 \
+    --max-seconds-per-candidate 9000 \
+    --hypothesis-seed "close productness_neg_acc gap below 0.85" \
+    > research_loop/autoreason_student_v2.log 2>&1 &
+
+# Real run on dino_v2 teacher (productness ON; ~50h × per-candidate budget)
+nohup .venv/bin/python -u -m research_loop.tournament autoreason \
+    --target dino_v2 \
+    --max-passes 10 \
+    --convergence 2 \
+    --max-seconds-per-candidate 18000 \
+    > research_loop/autoreason_dino_v2.log 2>&1 &
+```
+
+What each pass does (no manual steps):
+
+1. **Critic LLM** reads `train_v2.py` + last 30 rows of `results_v2.tsv` + last 10 outcome JSON records → produces a structured `Critique`. CritiqueRecord written to history.
+2. **Author B LLM** reads critique + trainer source → produces a unified-diff patch. PatchProposalRecord written.
+3. **Synthesizer LLM** reads A's empty patch + B's patch (anonymized X/Y labels, no metric history) → produces a conservative AB synthesis patch. SynthesisRecord written.
+4. For each kind ∈ {A, B, AB}: `apply_patch` (V1-safety + revert-on-exit) → `adapter.train(max_seconds=N)` → parse metrics → `Outcome` record. Working tree restored after each candidate.
+5. `promote.decide()` picks winner under guardrails (`combined > A + 0.003`, `recall@1` not regressed, `productness_neg_acc` not regressed, status=success). `Decision` record written.
+6. If A won → consecutive_count++. If `>= --convergence`, exit 0. Else next pass.
+7. On `--max-passes` exhausted: exit non-zero, decision history preserved.
+
+**Pre-conditions:**
+- `ANTHROPIC_API_KEY` set in env or `~/.hermes/.env`
+- Working tree clean (autoreason refuses dirty trees — patches need to revert cleanly)
+- `productness_val_paths.txt` regenerated (see §1)
+
+**Cost ceiling (default 15 passes × 5 LLM calls):** ≤ ~$5 per autoreason run on `claude-sonnet-4-6`. If you remove the time budget, a single hallucinated patch could chew 50h GPU. Always set `--max-seconds-per-candidate`.
+
+**Audit trail:** `research_loop/history.jsonl` records every LLM call's raw text plus parsed dataclass fields. A 5-pass run writes ≥ 50 records spanning candidate / outcome / decision / critique / patch_proposal / synthesis types. Replayable post-hoc.
+
+### 2b. Manual baseline run (when LLM access is unavailable)
+
+If you can't reach the Anthropic API, fall back to the original `run-round --baseline-only` flow:
+
+```bash
+nohup .venv/bin/python -u -m research_loop.tournament run-round \
+    --target student_v2 --baseline-only \
     > student_finetune/run_v2_production.log 2>&1 &
 ```
 
-What `run-round --baseline-only` does:
-1. **propose**: assigns a fresh `round_id`, writes a kind=A candidate to `research_loop/history.jsonl` (no B/AB — `--baseline-only`)
-2. **rank**: judges score the single A candidate
-3. **run**: subprocess `train_v2.py` (or `train_dino_v2.py`) with `DEFAULT_EPOCHS` (30 / 20)
-4. After training: parses `metrics_final_v2.json`, writes an `Outcome` record to `history.jsonl`, appends a row to `results_v2.tsv` via the V2-only adapter
-5. **promote**: applies `decide()` guardrails. With only A in the round, A wins by default; a `Decision` record records the deployment-gate verdict from `is_deployable()`.
+This emits a single A candidate, runs it, and writes the Outcome+Decision records — no Critic/Author B/Synthesizer, just the productization path.
 
-Stage 1 writes the LoRA adapter to `dino_finetune/output/best_adapter/`. Stage 2 reads it from the same path. The teacher embedding cache is keyed on the adapter's SHA-256 prefix (`workspace/output/teacher_cache/dinov3_ft/<adapter_sha>/`), so a teacher retrain → new sha → fresh cache subdir built automatically on first student epoch. No `mv`, no `rm -rf`, no swap.
+### 2c. Single-candidate experiments
 
-Stage 2 first-epoch is ~14 min (cache warmup); subsequent epochs ~5–8 min.
-
-### 2b. Subsequent experiments (after baseline lands)
+To run a hand-crafted patch outside the autoreason loop:
 
 ```bash
-# Propose a real experiment (B/AB will need real patches before run)
-.venv/bin/python -m research_loop.tournament propose \
-    --target student_v2 \
-    --hypothesis "raise commodity_ratio from 0.15 to 0.20"
-# Edit the patches in research_loop/history.jsonl, then:
+.venv/bin/python -m research_loop.tournament propose --target student_v2 --hypothesis "..."
+# Edit the B / AB patches in research_loop/history.jsonl, then:
 .venv/bin/python -m research_loop.tournament run --candidate <B_id>
-.venv/bin/python -m research_loop.tournament run --candidate <AB_id>
 .venv/bin/python -m research_loop.tournament promote --round <round_id>
 ```
+
+### Cache / adapter notes (apply to all 3 modes)
+
+Stage-1 (DINO) writes the LoRA adapter to `dino_finetune/output/best_adapter/`. Stage-2 (student) reads it from the same path. The teacher embedding cache is keyed on the adapter's SHA-256 prefix (`workspace/output/teacher_cache/dinov3_ft/<adapter_sha>/`) — a teacher retrain → new sha → fresh cache subdir built automatically. No `mv`, no `rm -rf`, no swap. Student first-epoch is ~14 min (cache warmup); subsequent epochs ~5–8 min.
 
 Watch progress:
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -180,6 +180,8 @@ Per project decision, autoreason calls a local CLI (`hermes`, `claude`, or `code
 | `claude` | `--llm-cli claude` | `--model claude-sonnet-4-6` |
 | `codex` | `--llm-cli codex` | `--model gpt-5` (passed via `codex exec -c model=...`) |
 
+Hermes routes through 21 providers (`auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `anthropic`, `gemini`, `xai`, `ollama-cloud`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `stepfun`, `minimax`, `kilocode`, `xiaomi`, `arcee`, `nvidia`, …). Pick via `--llm-provider <name>`.
+
 Selection order: explicit `--llm-cli` flag → `AUTORESEARCH_LLM_CLI` env var → default `hermes`.
 
 ```bash
@@ -195,7 +197,36 @@ Selection order: explicit `--llm-cli` flag → `AUTORESEARCH_LLM_CLI` env var �
 .venv/bin/python -m research_loop.tournament autoreason \
     --target student_v2 --max-passes 1 --dry-run \
     --llm-cli codex
+
+# hermes routing through Gemini
+.venv/bin/python -m research_loop.tournament autoreason \
+    --target student_v2 --max-passes 1 --dry-run \
+    --llm-cli hermes --llm-provider gemini --llm-model gemini-2.0-flash-thinking-exp
 ```
+
+### 2d-bis. Mixed-model setups (per-role overrides)
+
+Autoreason paper §7.3 (Judge Ablation) showed that pairing a cheap author with a strong judge still beats single-pass — autoreason's structure provides "a weaker form of external evaluation" even when models differ across roles. Same flexibility is exposed here:
+
+```bash
+# Strong Critic (analytical), cheap Author (creative volume), conservative Synthesizer
+.venv/bin/python -m research_loop.tournament autoreason \
+    --target student_v2 --max-passes 15 --convergence 2 \
+    --max-seconds-per-candidate 9000 \
+    --critic-cli claude        --critic-model claude-opus-4-7 \
+    --author-cli hermes        --author-model anthropic/claude-haiku-4-5 \
+    --synthesizer-cli claude   --synthesizer-model claude-sonnet-4-6
+```
+
+Each role flag pair (`--{role}-cli` + `--{role}-model`) overrides the global `--llm-cli` / `--llm-model`. Roles you don't specify inherit the default. Three role keys: `critic`, `author`, `synthesizer`.
+
+Why mix:
+
+- **Critic** is analytical — finds problems in code + history. Benefits from a strong reasoning model (Opus / Gemini Pro).
+- **Author** is creative — generates patches at temperature 0.8. A cheap, fast model can produce diverse candidates inexpensively (the tournament's promotion guardrails reject bad ones anyway).
+- **Synthesizer** is conservative — combines A and B at half-strength. A balanced model (Sonnet 4.6) is often best.
+
+If you don't care about mixing, omit the per-role flags and everything uses `--llm-cli` / `--llm-model`.
 
 ### 2e. Real-LLM smoke (T8 — pre-flight before launching autoreason)
 

--- a/PLAN-AUTOREASON.md
+++ b/PLAN-AUTOREASON.md
@@ -1,0 +1,225 @@
+# Implementation Plan: Autoreason loop for ML training (issue #11)
+
+Companion to [SPEC-AUTOREASON.md](SPEC-AUTOREASON.md). Plans the work into vertical slices; each slice delivers something testable on its own. Goal: one PR with multi-commit history, ≤ 8 tasks, each ≤ 5 files.
+
+## Overview
+
+We have the **evaluation/execution layer** (research_loop from PR #8). We need the **generation layer**: 3 LLM agents (Critic / Author B / Synthesizer) plus an orchestrator loop that runs them, applies their patches, runs training under a time budget, and converges via objective ML metrics. After this PR, `tournament autoreason --target student_v2` runs autonomously to convergence.
+
+## Architecture Decisions
+
+- **Single LLM model (Sonnet 4.6) for all 3 roles** — start simple; per-role tier can come later if cost matters.
+- **Anthropic SDK directly, no litellm** — fewer indirections, prompt-cache friendly.
+- **Patches via `git apply` / `git apply -R`** — fully reversible, every pass leaves working tree clean. Revert is the single source of truth for "did this round happen safely".
+- **No LLM judges** — objective ML metrics through the existing `promote.decide()`. The paper's Borda is for subjective domains; we have measurable outcomes.
+- **Time budget enforced at the adapter layer** — subprocess SIGTERM + 30s grace + SIGKILL. Recovery via `metrics_progress_v2.json` written by the trainer after each eval cycle.
+- **Convergence: k=2 consecutive A wins** — paper's calibrated default; max-passes 15 ceiling.
+- **Audit trail: every LLM call's full text persisted** to `history.jsonl` as `record_type ∈ {"critique", "patch_proposal", "synthesis"}`. Replayable post-hoc.
+- **V2-only safety reused** — Author B's prompt forbids V1 edits; patch applicator double-checks before `git apply`. Belt and suspenders.
+
+## Dependency Graph
+
+```
+metrics_progress writes (B0)         git apply/revert (P0)
+       │                                     │
+       ▼                                     ▼
+adapter.train(max_seconds) (B1) ─────► PatchApplicator (P1)
+       │                                     │
+       └──────────────► AgentClient (A1) ◄──┘
+                              │
+            ┌─────────────────┼─────────────────┐
+            ▼                 ▼                 ▼
+        CriticAgent     AuthorBAgent     SynthesizerAgent
+           (A2)              (A3)              (A4)
+            │                 │                 │
+            └─────────────────┼─────────────────┘
+                              ▼
+                     Convergence loop (L1)
+                              │
+                              ▼
+                  `tournament autoreason` CLI (L2)
+                              │
+                              ▼
+                Mocked end-to-end integration (V1)
+                              │
+                              ▼
+                  Manual smoke with real LLM (V2)
+```
+
+## Task List
+
+### Phase 1: Primitives (foundation)
+
+#### Task 1: Trainers write `metrics_progress_v2.json` after each eval
+
+Both `student_finetune/train_v2.py` and `dino_finetune/train_dino_v2.py` already evaluate every epoch. Add a small write of `metrics_progress_v2.json` (same schema as `metrics_final_v2.json` plus `epochs_completed` and `is_partial=true`). Lets the time-budget recovery path read partial state without race conditions.
+
+- **Acceptance:**
+  - [ ] `metrics_progress_v2.json` written atomically after every eval (write-to-tmp + rename)
+  - [ ] Schema matches `metrics_final_v2.json` keys, plus `is_partial: bool`, `epochs_completed: int`
+  - [ ] V1 trainer behavior unchanged
+- **Verification:** existing `test_productness_integration_smoke.py` still passes; new `test_metrics_progress_write.py` confirms file written + schema correct
+- **Files:** `student_finetune/train_v2.py`, `dino_finetune/train_dino_v2.py`, `student_finetune/tests/test_metrics_progress_write.py`
+- **Dependencies:** none — additive
+- **Scope:** S
+
+#### Task 2: Time-budget primitive in `adapter.train()`
+
+`adapter.train(candidate, max_seconds=N)` enforces wall-clock; SIGTERM, 30s grace, SIGKILL. On timeout, parse `metrics_progress_v2.json` if present; status becomes `"timeout"`.
+
+- **Acceptance:**
+  - [ ] Adapter kills overrunning subprocess within 60s of `max_seconds`
+  - [ ] Returns `TrainOutcome(status="timeout", metrics={partial}, return_code=-9 or similar)`
+  - [ ] `promote.decide()` rejects timeout candidates regardless of partial metrics
+- **Verification:** `pytest research_loop/tests/test_budget.py` (stub trainer that sleeps) — green; existing tests still pass
+- **Files:** `research_loop/targets/_base.py`, `research_loop/promote.py`, `research_loop/tests/test_budget.py`
+- **Dependencies:** Task 1 (for partial metrics recovery)
+- **Scope:** M (3 files)
+
+#### Task 3: Patch applicator (`research_loop/patch.py`)
+
+Context manager that applies a unified diff via `git apply`, reverts on exit. Refuses any patch touching `V1_FORBIDDEN_PATHS`. Validates with `git apply --check` before apply.
+
+- **Acceptance:**
+  - [ ] `apply_patch(diff, repo)` is a `@contextmanager`; revert runs in `finally`
+  - [ ] V1-touching patches raise `ValueError` before any filesystem mutation
+  - [ ] Malformed patches raise `subprocess.CalledProcessError` (caught upstream)
+- **Verification:** `pytest research_loop/tests/test_patch_applicator.py` — apply/revert roundtrip on tmp git repo, V1 refusal, malformed diff handling
+- **Files:** `research_loop/patch.py`, `research_loop/tests/test_patch_applicator.py`
+- **Dependencies:** none
+- **Scope:** S (2 files)
+
+### Checkpoint A: Primitives (after T1–T3)
+
+- [ ] All three primitives pass their unit tests
+- [ ] Existing 103 PR-#8 tests still green
+- [ ] `git status` clean after `pytest` runs (revert always reverts)
+
+---
+
+### Phase 2: Agents (generation layer)
+
+#### Task 4: `AgentClient` wrapper (`research_loop/agents/client.py`)
+
+Thin Anthropic SDK wrapper. Reads API key from env, falls back to `~/.hermes/.env`. Single shared instance per process. Prompt caching enabled on system prompts for cross-call reuse within a pass. No retries inside the wrapper — let upstream handle.
+
+- **Acceptance:**
+  - [ ] `AgentClient.call(system, user, *, temperature)` returns the raw assistant text
+  - [ ] Uses `cache_control={"type": "ephemeral"}` on the system block
+  - [ ] Raises clear error when API key missing
+- **Verification:** `pytest research_loop/tests/test_agent_client.py` — mocks `anthropic.Anthropic`, asserts the request shape (system block has cache_control, user message correct, no message history persisted across calls)
+- **Files:** `research_loop/agents/__init__.py`, `research_loop/agents/client.py`, `research_loop/tests/test_agent_client.py`
+- **Dependencies:** none (just adds `anthropic` to pyproject.toml deps)
+- **Scope:** S
+
+#### Task 5: `CriticAgent`, `AuthorBAgent`, `SynthesizerAgent`
+
+Three `dataclass`-result agents. Each has a fixed system prompt (paper-style), a `render()` for the user message, and a `parse()` that turns LLM output into a typed object (`Critique` / `PatchProposal` / `Synthesis`). All three persist `raw` field for audit.
+
+- **Acceptance:**
+  - [ ] `Critique(summary, problems, raw)` from CriticAgent
+  - [ ] `PatchProposal(rationale, diff, raw)` from AuthorBAgent — `diff` is a unified-diff string
+  - [ ] `Synthesis(rationale, diff, raw)` from SynthesizerAgent — same format as PatchProposal
+  - [ ] Author B's user message includes critic output and the trainer source; system prompt forbids V1 edits explicitly
+  - [ ] Synthesizer sees only A and B's patches with anonymized labels (no metric history)
+- **Verification:** `pytest research_loop/tests/test_agents.py` — `monkeypatch` `AgentClient.call` to canned responses, assert parsing produces typed objects with expected fields
+- **Files:** `research_loop/agents/critic.py`, `research_loop/agents/author.py`, `research_loop/agents/synthesizer.py`, `research_loop/tests/test_agents.py`
+- **Dependencies:** Task 4 (AgentClient)
+- **Scope:** M (4 files)
+
+### Checkpoint B: Agents (after T4–T5)
+
+- [ ] Agents pass parsing tests with mocked LLM
+- [ ] Patches produced by AuthorB/Synthesizer in tests pass `git apply --check`
+- [ ] Each agent's call is fresh (no message history mutation between calls in the same process)
+
+---
+
+### Phase 3: Orchestration
+
+#### Task 6: Convergence loop in `tournament.py`
+
+Adds `tournament autoreason` subcommand. Each pass: Critic → Author B → Synthesizer → apply patches in turn (each in its own `apply_patch` context) → adapter.train under budget → promote.decide → write Decision. Track consecutive A wins; terminate at `k=2` or `--max-passes`.
+
+Persists each LLM call's raw text into `history.jsonl` as `record_type ∈ {"critique", "patch_proposal", "synthesis"}` (extends `Candidate / Outcome / Decision` discriminated union).
+
+- **Acceptance:**
+  - [ ] `tournament autoreason --target student_v2 --max-passes N --convergence k --max-seconds-per-candidate S` end-to-end
+  - [ ] Working tree clean after every pass (revert in `finally`)
+  - [ ] Convergence at k consecutive A wins → exit
+  - [ ] Hitting max-passes prints clear "did not converge" + exits with non-zero code
+  - [ ] Author/Synthesizer patches recorded as candidates with `kind ∈ {"B", "AB"}`
+- **Verification:** `pytest research_loop/tests/test_autoreason_loop.py` with mocked AgentClient + stub adapter — convergence test, max-passes test, working-tree-clean assertion
+- **Files:** `research_loop/tournament.py`, `research_loop/candidate.py` (extend record types), `research_loop/tests/test_autoreason_loop.py`
+- **Dependencies:** Tasks 1–5
+- **Scope:** M (3 files)
+
+### Checkpoint C: Orchestration (after T6)
+
+- [ ] `tournament autoreason --dry-run` runs end-to-end on CPU
+- [ ] Synthetic 5-pass scenario reaches convergence at k=2
+- [ ] Total LLM calls per pass ≤ 5 (no judge calls)
+- [ ] All previous tests still green
+
+---
+
+### Phase 4: Polish
+
+#### Task 7: Audit trail + HANDOFF.md update
+
+Make sure every LLM call writes its raw text into `history.jsonl` (not just the parsed dataclass). Update `HANDOFF.md` with the new "Stage 1 / Stage 2 via `tournament autoreason`" section, replacing the prior "manual `run-round --baseline-only`" instructions.
+
+- **Acceptance:**
+  - [ ] Replaying a `history.jsonl` reconstructs every LLM call (raw text preserved verbatim)
+  - [ ] HANDOFF.md describes how to launch the autonomous loop and how to interpret a run
+- **Verification:** unit test reads a mock history.jsonl and asserts all expected `record_type` values present; HANDOFF reads cleanly to a new engineer
+- **Files:** `research_loop/tournament.py` (audit hooks), `HANDOFF.md`
+- **Dependencies:** Task 6
+- **Scope:** S (2 files)
+
+#### Task 8: Real-LLM smoke (manual, not in CI)
+
+One pass against the current `train_v2.py` with a real Anthropic API key, but `--dry-run-train` (skip GPU). Confirms: prompt → critique → diff → applies cleanly via `git apply --check` → reverts. Document the run in HANDOFF.md as a one-time manual verification.
+
+- **Acceptance:**
+  - [ ] Real Sonnet 4.6 call returns a parseable critique
+  - [ ] Author B's diff applies via `git apply --check` without errors
+  - [ ] Synthesizer's diff also applies cleanly
+  - [ ] Working tree clean after revert
+- **Verification:** manual run + record output snippet in HANDOFF.md
+- **Files:** `HANDOFF.md` only (records the smoke evidence)
+- **Dependencies:** Task 6
+- **Scope:** XS
+
+### Checkpoint D: Complete
+
+- [ ] All tasks T1–T8 complete
+- [ ] `pytest -q` 100% green
+- [ ] Manual smoke (T8) recorded
+- [ ] Single PR with 7-8 atomic commits ready for review
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| LLM produces unapplyable diff | High | `git apply --check` before apply; malformed → that candidate skipped, not whole loop |
+| LLM tries to edit V1 file | High | Author B system prompt forbids; patch applicator double-checks `V1_FORBIDDEN_PATHS` before `git apply` |
+| Subprocess SIGTERM doesn't unblock CUDA | Medium | 30s grace then SIGKILL; CUDA process gets killed regardless |
+| Working tree dirty before pass | High | Tournament refuses to start unless `git status --porcelain` is empty (operator must commit/stash) |
+| Cost runaway (LLM calls × passes) | Medium | Hard caps: max-passes 15, ≤ 5 calls/pass, ≤ $5/run on Sonnet 4.6 |
+| Cache-pollution between passes | Medium | Adapter-sha cache keying (already shipped in PR #8) — patches that change LoRA training change the sha automatically |
+| Convergence never reached | Low | max-passes ceiling exits with non-zero; operator inspects history.jsonl |
+| LLM hallucinates a metric improvement | High | objective `promote.decide()` is the only path to "winner" — LLM cannot vote |
+
+## Open Questions
+
+(Resolved per user direction 2026-04-25:)
+- Patch path style: `a/student_finetune/train_v2.py` (repo-rooted) ✅
+- Malformed diff: skip that candidate, round continues ✅
+- Synthesizer sees only patches, no metrics ✅
+
+No further open questions before implementation.
+
+## Parallelization
+
+All tasks have linear dependencies (T1 → T2 ... → T6 → T7 → T8). Single-agent linear implementation is fine; can't meaningfully parallelize without splitting between humans, which is not the case here.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,99 @@ cd student_finetune
 python -m pytest tests/ -x -q
 ```
 
+---
+
+## 🤖 Autoreason: training that improves itself overnight
+
+This repo ships a **fully autonomous research loop** modeled on the [NousResearch autoreason paper](https://github.com/NousResearch/autoreason). Three fresh LLM agents — **Critic**, **Author B**, **Synthesizer** — generate code patches, run them under a time budget, and let objective ML metrics pick the winner. Loops until the incumbent wins `k=2` consecutive rounds. **Zero human intervention between passes.**
+
+```
+Each pass:
+  Critic LLM  ─── reads train_v2.py + last 30 results_v2.tsv rows + last 10 outcomes
+              └─→ structured Critique (problems only, no fixes)
+
+  Author B LLM ── reads critique + trainer source
+              └─→ unified-diff patch (the new candidate B)
+
+  Synthesizer LLM ── reads A + B's patch (anonymized X / Y, no metrics)
+              └─→ conservative AB synthesis patch
+
+  For each kind ∈ {A, B, AB}:
+      git apply (V1-safety + auto-revert)
+        → adapter.train(max_seconds=N) → metrics
+        → promote.decide() with productness-aware guardrails
+        → Outcome record persisted to history.jsonl
+
+  Decision recorded. If A won → consecutive_count++. Convergence at k=2.
+```
+
+### Quickstart — pre-flight smoke (~30s, ~3 LLM calls)
+
+Verify the LLM round-trip works before launching a multi-hour training run:
+
+```bash
+# Default: hermes (matches the repo's existing autoresearch convention)
+.venv/bin/python -m research_loop.tools.autoreason_smoke
+
+# Or pick a specific CLI
+.venv/bin/python -m research_loop.tools.autoreason_smoke --llm-cli claude --llm-model claude-sonnet-4-6
+.venv/bin/python -m research_loop.tools.autoreason_smoke --llm-cli codex
+```
+
+### Recommended config — mixed-model setup
+
+Different roles benefit from different model classes (paper §7.3). Suggested baseline that respects token budgets:
+
+| Role | CLI | Why |
+|---|---|---|
+| **Critic** (analytical, low temp) | `hermes --provider openai-codex` | User-habit-tuned codex catches problems specific to your project |
+| **Author B** (creative volume, temp 0.8) | `codex` direct | Unlimited; built for code patches; raw diversity > habit constraints |
+| **Synthesizer** (conservative pick) | `hermes --provider openai-codex` | User-taste-tuned for "halve and keep the safer part" |
+
+```bash
+.venv/bin/python -m research_loop.tournament autoreason \
+    --target student_v2 \
+    --max-passes 15 --convergence 2 \
+    --max-seconds-per-candidate 9000 \
+    --critic-cli hermes --critic-model openai-codex/gpt-5-codex \
+    --author-cli codex --author-model gpt-5-codex \
+    --synthesizer-cli hermes --synthesizer-model openai-codex/gpt-5-codex
+```
+
+Or use Opus for everything if tokens aren't the bottleneck:
+
+```bash
+.venv/bin/python -m research_loop.tournament autoreason \
+    --target student_v2 \
+    --max-passes 15 --convergence 2 --max-seconds-per-candidate 9000 \
+    --llm-cli claude --llm-model claude-opus-4-7
+```
+
+### Escalation — break a stalled run
+
+If A keeps winning but `combined` plateaus, inject one Opus critic pass to surface a deeper analytical view:
+
+```bash
+.venv/bin/python -m research_loop.tournament autoreason \
+    --target student_v2 --max-passes 1 --convergence 99 \
+    --max-seconds-per-candidate 9000 \
+    --critic-cli claude --critic-model claude-opus-4-7 \
+    --author-cli codex --author-model gpt-5-codex \
+    --synthesizer-cli hermes --synthesizer-model openai-codex/gpt-5-codex
+```
+
+`--max-passes 1 --convergence 99` = "one pass, don't try to converge, just inject Opus's view". Then resume the cheap config.
+
+### Supported CLIs
+
+`hermes` (default), `claude`, `codex`. Selection precedence: explicit `--llm-cli` flag → `AUTORESEARCH_LLM_CLI` env var → `hermes`. Hermes routes through 21 providers (`auto`, `openrouter`, `nous`, `anthropic`, `gemini`, `xai`, `ollama-cloud`, `huggingface`, `kimi-coding`, `stepfun`, `minimax`, `arcee`, `nvidia`, …) — pick via `--llm-provider <name>`.
+
+### Audit trail
+
+Every LLM call's raw text is persisted to `research_loop/history.jsonl` as `record_type ∈ {critique, patch_proposal, synthesis, candidate, outcome, decision}`. A 5-pass run writes 50+ replayable records.
+
+See [HANDOFF.md](HANDOFF.md) for the full operator runbook (modes 2a / 2b / 2c, cache invariants, smoke procedure, troubleshooting).
+
 ## Adding New Research Topics
 
 Create a new subfolder following the existing pattern:

--- a/README.md
+++ b/README.md
@@ -142,6 +142,43 @@ If A keeps winning but `combined` plateaus, inject one Opus critic pass to surfa
 
 Every LLM call's raw text is persisted to `research_loop/history.jsonl` as `record_type ∈ {critique, patch_proposal, synthesis, candidate, outcome, decision}`. A 5-pass run writes 50+ replayable records.
 
+### "How is training going?" — Slack-bot-friendly status
+
+Every autoreason run writes a single canonical summary file an external agent can read:
+
+```
+research_loop/runs/<run_id>/
+  ├── summary.json       ← structured run state, refreshed every pass
+  ├── autoreason.log     ← narrative output (Critic findings, decisions, errors)
+  └── autoreason.pid     ← process id (for liveness check)
+```
+
+A `<target>_CURRENT.txt` pointer in `research_loop/runs/` tracks the active run per target.
+
+One command bots can run to answer "what's happening?":
+
+```bash
+$ .venv/bin/python -m research_loop.tournament status --target student_v2
+
+autoreason status — student_v2
+  Run:          run1777891234-a3f8c9 (alive (4h 23m))
+  Started:      2026-04-26T12:34:56Z
+  Status:       running
+  Pass:         5 / 15  (consecutive A wins: 1 / 2)
+  Last decision: A wins (round r1777891234-abc, deployable=True)
+                 reason: candidate B beats A by Δcombined=+0.0034, recall@1=0.9012 vs A=0.8989
+  Best so far:  combined=0.8341  recall@1=0.9012  neg_acc=0.84
+  Latest critique: productness neg_acc plateau at 0.84; commodity ratio may be too high
+  Logs:
+    narrative: research_loop/runs/run1777891234-a3f8c9/autoreason.log
+    history:   research_loop/history.jsonl (60 records)
+    run dir:   research_loop/runs/run1777891234-a3f8c9
+```
+
+Resolution order: `--run RUN_ID` → `--target TARGET` (uses CURRENT pointer) → newest run dir.
+
+Wire `tournament status` into a Slack slash-command, ntfy webhook, or Hermes tool — same shell command, paste output verbatim.
+
 See [HANDOFF.md](HANDOFF.md) for the full operator runbook (modes 2a / 2b / 2c, cache invariants, smoke procedure, troubleshooting).
 
 ## Adding New Research Topics

--- a/SPEC-AUTOREASON.md
+++ b/SPEC-AUTOREASON.md
@@ -26,12 +26,12 @@ Success = a `tournament autoreason` invocation can autonomously drive a multi-pa
 
 ## Tech stack
 
-- **LLM SDK**: Anthropic SDK (`anthropic` Python package). API key from `ANTHROPIC_API_KEY` env, falling back to `~/.hermes/.env` if loaded by repo convention.
-- **Model**: `claude-sonnet-4-6` for all three agent roles. Single model first (multi-tier later).
+- **LLM access**: subprocess to a local CLI — `hermes`, `claude`, or `codex`. **No raw API keys in this repo.** Auth and rate limits stay in whichever tool the operator already runs. Selection via `--llm-cli` flag or `AUTORESEARCH_LLM_CLI` env; default `hermes` (matches the existing `student_finetune/run_v2.sh` convention).
+- **Model passthrough**: `--llm-model` flag forwarded to whichever CLI is selected (e.g. `anthropic/claude-sonnet-4` for hermes, `claude-sonnet-4-6` for claude, `gpt-5` for codex).
 - **Patch format**: unified diff applied via `subprocess.run(["git", "apply", ...])`. Revert via `git apply -R`.
 - **Existing**: Python 3.10+, PyTorch, the research_loop infrastructure already in master.
 
-No new heavy dependencies — only `anthropic` SDK is added.
+No new pip dependencies — autoreason runs entirely on already-installed CLIs.
 
 ## Commands
 

--- a/SPEC-AUTOREASON.md
+++ b/SPEC-AUTOREASON.md
@@ -1,0 +1,207 @@
+# Spec: Autoreason loop for ML training (issue #11)
+
+Tracks GitHub issue [#11](https://github.com/joesu-angible/issues/11). Closes #10 as a sub-component.
+
+**Branch:** `feat/autoreason-llm-loop`
+
+## Objective
+
+The research_loop scaffold from PR #8 is the **evaluation/execution layer** of an autoreason-style tournament — Candidate/Outcome/Decision schema, V2-only target adapters, productness-aware promotion guardrails. What's missing is the **generation layer**: the autonomous LLM-driven proposer that makes autoreason actually autoreason. Today every B/AB candidate's patch is a `# TODO` placeholder a human fills in.
+
+This spec adds the generation layer. After this PR, `tournament autoreason --target student_v2 --max-passes 15` runs end-to-end without human intervention:
+
+```
+Pass 1:
+  A = current train_v2.py
+  Critic LLM ─→ critique
+  Author B LLM ─→ patch B (unified diff)
+  Synthesizer LLM ─→ patch AB (unified diff)
+  Apply patches in temp branches → run training (subject to per-candidate time budget)
+  promote.decide() over objective metrics → winner
+  → Winner becomes new A
+Pass 2: ... (until A wins k=2 consecutive, or max-passes reached)
+```
+
+Success = a `tournament autoreason` invocation can autonomously drive a multi-pass refinement loop on `train_v2.py` or `train_dino_v2.py`, terminate cleanly at convergence, and leave the working tree clean.
+
+## Tech stack
+
+- **LLM SDK**: Anthropic SDK (`anthropic` Python package). API key from `ANTHROPIC_API_KEY` env, falling back to `~/.hermes/.env` if loaded by repo convention.
+- **Model**: `claude-sonnet-4-6` for all three agent roles. Single model first (multi-tier later).
+- **Patch format**: unified diff applied via `subprocess.run(["git", "apply", ...])`. Revert via `git apply -R`.
+- **Existing**: Python 3.10+, PyTorch, the research_loop infrastructure already in master.
+
+No new heavy dependencies — only `anthropic` SDK is added.
+
+## Commands
+
+```bash
+# Run the full autoreason loop on student_v2 (autonomous; ~hours per pass)
+.venv/bin/python -m research_loop.tournament autoreason \
+    --target student_v2 \
+    --max-passes 15 \
+    --convergence 2 \
+    --max-seconds-per-candidate 9000 \
+    --hypothesis-seed "close productness_neg_acc gap below 0.85"
+
+# Single-pass dry-run with mocked LLM (fast, for tests)
+.venv/bin/python -m research_loop.tournament autoreason \
+    --target student_v2 --max-passes 1 --dry-run
+
+# Existing commands still work (propose / rank / run / promote / run-round)
+.venv/bin/python -m research_loop.tournament run-round --target student_v2 --baseline-only
+
+# Tests (CPU-only, mocked LLM + mocked subprocess)
+.venv/bin/python -m pytest research_loop/tests dino_finetune/tests student_finetune/tests/test_*productness*.py student_finetune/tests/test_adapter_sha.py -q
+```
+
+## Project structure
+
+```
+autoresearch/
+├── research_loop/
+│   ├── agents/                          # NEW — generation layer
+│   │   ├── __init__.py
+│   │   ├── client.py                    # Anthropic SDK wrapper, env-var key, retries
+│   │   ├── critic.py                    # CriticAgent: train_v2.py + history → Critique
+│   │   ├── author.py                    # AuthorBAgent: critique + train_v2.py → unified diff
+│   │   └── synthesizer.py               # SynthesizerAgent: A + B's patch → AB patch
+│   ├── patch.py                         # NEW — apply / revert unified diff via git apply
+│   ├── budget.py                        # NEW — wall-clock timeout primitive (was issue #10)
+│   ├── candidate.py                     # extended: PatchProposal, Critique dataclasses
+│   ├── promote.py                       # extended: timeout outcomes auto-rejected
+│   ├── targets/_base.py                 # extended: train(max_seconds=N) honors budget
+│   ├── tournament.py                    # extended: `autoreason` subcommand + convergence loop
+│   └── tests/
+│       ├── test_agents.py               # mocked LLM responses + parsing
+│       ├── test_patch_applicator.py     # apply/revert roundtrip
+│       ├── test_budget.py               # SIGTERM kill + timeout outcome
+│       └── test_autoreason_loop.py      # full convergence flow with stub adapters
+└── student_finetune/train_v2.py         # extended: writes metrics_progress_v2.json after each eval
+└── dino_finetune/train_dino_v2.py       # same
+```
+
+## Code style
+
+```python
+# research_loop/agents/client.py — thin wrapper, retries, prompt-cached system prompt
+class AgentClient:
+    """Single shared Anthropic SDK client with prompt caching enabled.
+
+    Uses ephemeral cache breakpoints on system prompts so the Critic / Author /
+    Synthesizer system messages get cached across calls within a pass. Each
+    role reuses the same client; fresh user-message context per call ensures
+    no shared chat history (the autoreason 'fresh agent' invariant).
+    """
+
+    def __init__(self, model: str = "claude-sonnet-4-6", max_tokens: int = 4096):
+        self.client = anthropic.Anthropic()
+        self.model = model
+        self.max_tokens = max_tokens
+
+    def call(self, system: str, user: str, *, temperature: float = 0.8) -> str:
+        resp = self.client.messages.create(
+            model=self.model,
+            max_tokens=self.max_tokens,
+            system=[{"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}],
+            messages=[{"role": "user", "content": user}],
+            temperature=temperature,
+        )
+        return resp.content[0].text
+
+
+# research_loop/agents/critic.py — typed, returns structured Critique
+@dataclass(frozen=True)
+class Critique:
+    summary: str
+    problems: list[str]      # bullet list — concrete, no fixes proposed
+    raw: str                 # full LLM text for audit log
+
+class CriticAgent:
+    SYSTEM_PROMPT = """You are reviewing a machine-learning training script and
+    its recent experiment history. Your only job is to identify concrete problems —
+    do not propose fixes. Be specific. Reference exact file:line locations or
+    metric values. If the run is healthy, say so explicitly."""
+
+    def __init__(self, client: AgentClient): self.client = client
+
+    def critique(self, trainer_src: str, history: list[Outcome],
+                 results_tsv_tail: str) -> Critique:
+        user = self._render_prompt(trainer_src, history, results_tsv_tail)
+        raw = self.client.call(self.SYSTEM_PROMPT, user, temperature=0.3)
+        return self._parse(raw)
+```
+
+Patches: unified diff produced by `Author B`, validated for V2 safety, applied with `git apply --check` first, then `git apply`. Revert via `git apply -R`.
+
+```python
+# research_loop/patch.py
+@contextmanager
+def apply_patch(patch_text: str, repo: Path):
+    """Apply unified diff; revert on context exit. Raises if patch touches V1 files."""
+    if _touches_v1(patch_text):
+        raise ValueError("Patch touches a V1_FORBIDDEN_PATHS file")
+    _git("apply", "--check", input=patch_text, cwd=repo)
+    _git("apply", input=patch_text, cwd=repo)
+    try:
+        yield
+    finally:
+        _git("apply", "-R", input=patch_text, cwd=repo)
+```
+
+## Testing strategy
+
+CPU-only unit + integration tests. No real GPU, no real LLM call in the test suite.
+
+- `research_loop/tests/test_agents.py` — Critic/Author/Synthesizer with `monkeypatch` on `AgentClient.call` returning canned strings. Verify parsing into typed objects, fresh-agent invariant (each `.critique()` call uses a new system+user pair, no message history mutation).
+- `research_loop/tests/test_patch_applicator.py` — apply/revert roundtrip on a tmp git repo (fixture); refusal when patch references `V1_FORBIDDEN_PATHS`.
+- `research_loop/tests/test_budget.py` — `adapter.train(max_seconds=2)` against a stub trainer that sleeps 5s; assert subprocess killed, status=`"timeout"`, partial metrics parsed if present.
+- `research_loop/tests/test_autoreason_loop.py` — full convergence with mocked LLM + stub adapter that returns deterministic Outcomes. Cover:
+  - convergence at k=2 (A wins twice → done)
+  - max-passes ceiling
+  - timeout candidate auto-rejected
+  - patch revert on round end (working tree clean after each pass)
+
+Coverage target: new code ≥ 80% line coverage.
+
+## Boundaries
+
+**Always:**
+- Use `anthropic.Anthropic()` for LLM calls; respect existing repo env conventions.
+- Apply patches via `git apply` and revert at the end of every pass — working tree must be the same after a pass as before.
+- Refuse any patch that touches `V1_FORBIDDEN_PATHS` (LLM may try; double-check after generation).
+- Write each LLM call's `raw` text into `research_loop/history.jsonl` for audit (`kind="critique"`, `"patch_proposal"`, `"synthesis"`).
+- Cap `max_seconds_per_candidate` even for production runs — autoreason without timeout could chew 50h on one bad LLM-generated patch.
+
+**Ask first:**
+- Adding any LLM provider beyond Anthropic SDK.
+- Increasing `max_passes` above 30.
+- Switching to LLM-as-judge (paper says don't for code/objective domains).
+- Allowing autoreason to write into V1 files.
+- Adding patches that introduce new files (Author B should be modifying existing trainers, not creating new modules).
+
+**Never:**
+- Commit the LLM `raw` text containing API keys or secrets.
+- Persist Anthropic API key in any committed file.
+- Run autoreason on a dirty working tree (we'd lose the user's uncommitted work).
+- Use `--no-verify` to bypass tests.
+- Skip the patch revert step — even on error paths, the `try/finally` must run.
+
+## Success criteria
+
+1. `tournament autoreason --target student_v2 --max-passes 1 --dry-run` runs in CI/CPU without launching real subprocess or hitting real LLM API.
+2. `test_autoreason_loop.py` proves a synthetic 5-pass run converges at k=2 and produces clean working tree after each pass.
+3. With real LLM (manual smoke), one pass against the current `train_v2.py` produces a valid Critique → unified-diff PatchProposal → unified-diff Synthesis. Patches apply via `git apply --check` without errors.
+4. Time budget: `adapter.train(max_seconds=N)` kills overrunning subprocess within 60s of expiry, returns `Outcome(status="timeout")`. `promote.decide()` rejects timeout candidates regardless of partial metrics.
+5. V2-only safety preserved end-to-end: a synthetic patch that edits `student_finetune/train.py` (V1) is rejected by `apply_patch` before `git apply` runs.
+6. Audit trail: after a 5-pass run on the synthetic test, `research_loop/history.jsonl` contains 5 critique records + 5 patch_proposal + 5 synthesis + 5×3 outcomes + 5 decisions = 40 records minimum, all replayable.
+7. Total LLM call count per pass ≤ 5 (1 Critic + 1 Author B + 1 Synthesizer + 0 judges, with retries counted separately).
+8. PR is single-branch, multi-commit (sub-tasks A–E from issue #11 land as separate atomic commits), 100% green tests on master at PR open time.
+
+## Open questions
+
+1. **Patch base directory**: Author B sees `student_finetune/train_v2.py` as input — should the unified diff use `a/student_finetune/train_v2.py` paths (repo-rooted) or just `a/train_v2.py`? Standard `git apply` from repo root expects the former. **Default assumption: repo-rooted paths.**
+2. **What if the LLM produces a malformed diff?** Today: error → that candidate skipped, round continues with whoever else has valid patches. If both B and AB malformed, A wins by default. **Default assumption: be lenient — single failure does not abort the loop.**
+3. **Should the Synthesizer see metric history when synthesizing AB?** Paper says synthesizer gets A + B with anonymized labels and "no drafting history." For ML, leaning toward keeping it pure — only the patches, not the metrics, to avoid the synthesizer over-fitting to one data point. **Default assumption: synthesizer sees A and B's patch only, no metrics.**
+
+→ Confirm or correct these and I'll move to the plan phase.

--- a/TASKS-AUTOREASON.md
+++ b/TASKS-AUTOREASON.md
@@ -1,0 +1,128 @@
+# Tasks: Autoreason loop for ML training (issue #11)
+
+Companion to [SPEC-AUTOREASON.md](SPEC-AUTOREASON.md) and [PLAN-AUTOREASON.md](PLAN-AUTOREASON.md).
+
+8 tasks, ordered by dependency. Each becomes one atomic commit on `feat/autoreason-llm-loop`.
+
+---
+
+## Phase 1 — Primitives
+
+- [ ] **T1. Trainers write `metrics_progress_v2.json` after each eval**
+  - Acceptance: file written atomically (write-temp-then-rename) after every retrieval+productness eval cycle in both trainers; schema matches `metrics_final_v2.json` plus `is_partial=true` and `epochs_completed: int`.
+  - Verify: `pytest student_finetune/tests/test_metrics_progress_write.py -q` passes; existing 103 tests stay green.
+  - Files: `student_finetune/train_v2.py`, `dino_finetune/train_dino_v2.py`, `student_finetune/tests/test_metrics_progress_write.py`.
+  - Commit message: `feat(trainers): write metrics_progress_v2.json after each eval for timeout recovery`
+
+- [ ] **T2. `adapter.train(max_seconds=N)` time budget**
+  - Acceptance: subprocess SIGTERM at budget, 30s grace, then SIGKILL; `TrainOutcome(status="timeout", metrics={partial})` returned; partial metrics parsed from `metrics_progress_v2.json` if present. `promote.decide()` rejects timeout candidates regardless of metric values.
+  - Verify: `pytest research_loop/tests/test_budget.py -q`. Stub trainer that sleeps past `max_seconds`; confirm kill timing within 60s of expiry, status=`"timeout"`.
+  - Files: `research_loop/targets/_base.py`, `research_loop/promote.py`, `research_loop/tests/test_budget.py`.
+  - Commit message: `feat(research_loop): per-trial time budget via adapter.train(max_seconds=N)`
+
+- [ ] **T3. `research_loop/patch.py` — apply / revert unified diffs**
+  - Acceptance: `apply_patch(diff_text, repo)` is a `@contextmanager`; revert runs in `finally` even on exception; refuses any diff that touches `V1_FORBIDDEN_PATHS` (raises `ValueError` *before* any `git apply`); validates with `git apply --check` before apply.
+  - Verify: `pytest research_loop/tests/test_patch_applicator.py -q` — apply/revert roundtrip on a tmp git repo fixture; V1 refusal; malformed diff handling; revert-on-exception path.
+  - Files: `research_loop/patch.py`, `research_loop/tests/test_patch_applicator.py`.
+  - Commit message: `feat(research_loop): patch applicator with V1 safety + revert-on-exit`
+
+### ✅ Checkpoint A — Primitives complete
+
+```
+pytest research_loop/tests/test_budget.py \
+       research_loop/tests/test_patch_applicator.py \
+       student_finetune/tests/test_metrics_progress_write.py -q
+```
+
+All previous (PR #8) tests stay green. `git status` is clean after the suite (revert always runs).
+
+---
+
+## Phase 2 — Agents
+
+- [ ] **T4. `AgentClient` Anthropic SDK wrapper**
+  - Acceptance: `research_loop/agents/client.py` exposes `AgentClient(model, max_tokens)` with `.call(system, user, *, temperature)` returning the raw assistant text. System prompt sent with `cache_control={"type": "ephemeral"}`. API key read from `ANTHROPIC_API_KEY`, falling back to `~/.hermes/.env` parsing. No retries inside (let upstream handle).
+  - Verify: `pytest research_loop/tests/test_agent_client.py -q` — mock `anthropic.Anthropic.messages.create`; assert request shape (system block has cache_control; user content correct; no chat history persisted across calls).
+  - Files: `research_loop/agents/__init__.py`, `research_loop/agents/client.py`, `research_loop/tests/test_agent_client.py`, `pyproject.toml` (add `anthropic` dep).
+  - Commit message: `feat(agents): Anthropic SDK wrapper with prompt caching`
+
+- [ ] **T5. CriticAgent + AuthorBAgent + SynthesizerAgent**
+  - Acceptance: three agents in `research_loop/agents/{critic,author,synthesizer}.py` each producing a frozen dataclass result (`Critique`, `PatchProposal`, `Synthesis`). System prompts explicitly:
+    - Critic: "find problems only, no fixes proposed"
+    - Author B: "produce a unified diff addressing each criticism, no edits outside identified problems, no V1 file edits"
+    - Synthesizer: "given two patches A and B with anonymized labels, produce a synthesis that takes the strongest elements of each"
+  - User-message input contracts (typed):
+    - Critic: trainer source + last 30 rows of `results_v2.tsv` + last 10 Outcomes
+    - Author B: critique text + trainer source
+    - Synthesizer: just A and B's patches + the original critique (no metric history)
+  - Each result preserves `raw: str` for audit.
+  - Verify: `pytest research_loop/tests/test_agents.py -q` — `monkeypatch` `AgentClient.call` with canned responses (Critique with 3 problems, AuthorB with a valid unified diff that `git apply --check` accepts on a fixture trainer file, Synthesizer with another valid diff). Assert parsed dataclasses populated; assert each agent uses a fresh user-message (no history mutation).
+  - Files: `research_loop/agents/critic.py`, `research_loop/agents/author.py`, `research_loop/agents/synthesizer.py`, `research_loop/tests/test_agents.py`.
+  - Commit message: `feat(agents): Critic / Author B / Synthesizer with typed dataclass results`
+
+### ✅ Checkpoint B — Agents complete
+
+```
+pytest research_loop/tests/test_agent_client.py \
+       research_loop/tests/test_agents.py -q
+```
+
+Full suite still green (existing + new agent tests).
+
+---
+
+## Phase 3 — Orchestration
+
+- [ ] **T6. `tournament autoreason` subcommand + convergence loop**
+  - Acceptance: new CLI subcommand:
+    ```
+    tournament autoreason --target {student_v2|dino_v2} \\
+        --max-passes 15 --convergence 2 \\
+        --max-seconds-per-candidate N \\
+        [--hypothesis-seed "..."] [--dry-run]
+    ```
+    Each pass: refuse if `git status` dirty → Critic → Author B → Synthesizer → for each kind ∈ {A, B, AB}: apply patch (A is no-op), `adapter.train(max_seconds)`, revert → `promote.decide()` → write `Decision`. Track consecutive A wins; exit at `k` or `max_passes`. Exit code 0 on convergence, non-zero on max-passes-exhausted. Persists *every* LLM call's raw text into `history.jsonl` as `record_type ∈ {"critique", "patch_proposal", "synthesis"}`.
+  - Verify: `pytest research_loop/tests/test_autoreason_loop.py -q` with mocked LLM + stub adapter:
+    - convergence at k=2 (A wins twice) → exit code 0
+    - max-passes ceiling → exit code != 0
+    - timeout candidate auto-rejected by promote.decide
+    - working tree clean after every pass (assert via fixture git repo)
+    - history.jsonl contains expected record_type sequence
+  - Files: `research_loop/tournament.py` (extend), `research_loop/candidate.py` (add `Critique`/`PatchProposal`/`Synthesis` record types in the discriminated union), `research_loop/tests/test_autoreason_loop.py`.
+  - Commit message: `feat(research_loop): autoreason convergence loop + tournament autoreason CLI`
+
+### ✅ Checkpoint C — Orchestration complete
+
+```
+.venv/bin/python -m pytest research_loop/tests dino_finetune/tests \
+    student_finetune/tests/test_*productness*.py \
+    student_finetune/tests/test_adapter_sha.py \
+    student_finetune/tests/test_metrics_progress_write.py -q
+```
+
+Total tests: 103 (PR #8) + new T1–T6 tests. All green. End-to-end CPU dry-run of `tournament autoreason --max-passes 1 --dry-run` produces a clean run with mocked LLM and mocked subprocess.
+
+---
+
+## Phase 4 — Polish
+
+- [ ] **T7. Audit trail + HANDOFF.md update**
+  - Acceptance: every LLM call's raw text appears in `history.jsonl` (not just parsed objects); HANDOFF.md replaces the "Stage 1 / Stage 2 via `run-round --baseline-only`" section with the autonomous-loop launcher; mentions cost ceiling + max-passes + how to interpret convergence vs max-passes-exhausted.
+  - Verify: unit test reads a fixture `history.jsonl` from a 3-pass synthetic run and asserts every expected `record_type` occurs (`candidate × 3 kinds × 3 passes` + outcomes + decisions + critique/patch_proposal/synthesis).
+  - Files: `research_loop/tournament.py` (audit hooks if not already present), `HANDOFF.md`.
+  - Commit message: `docs(handoff): replace run-round with autonomous tournament autoreason flow`
+
+- [ ] **T8. Real-LLM smoke (manual, not CI)**
+  - Acceptance: one manual run: `tournament autoreason --target student_v2 --max-passes 1 --dry-run-train` (skip GPU). Real Sonnet 4.6 call. Output: a critique that's plausibly relevant + an Author-B diff that passes `git apply --check` + a Synthesizer diff that also passes. Snippet recorded in HANDOFF.md as one-time evidence.
+  - Verify: manual; the snippet IS the verification.
+  - Files: `HANDOFF.md`.
+  - Commit message: `docs(handoff): real-LLM smoke recorded — autoreason produces applyable diffs`
+
+### ✅ Checkpoint D — Complete
+
+- [ ] All 8 tasks committed atomically on `feat/autoreason-llm-loop`
+- [ ] Single PR opened against `master`, body references issue #11
+- [ ] Working tree clean
+- [ ] Manual T8 evidence recorded
+- [ ] Issue #10 stays closed (its scope is fulfilled by T2)
+- [ ] Issue #11 closes when this PR merges

--- a/dino_finetune/train_dino_v2.py
+++ b/dino_finetune/train_dino_v2.py
@@ -882,6 +882,32 @@ def main():
             current_recall = metrics["recall@1"]
             current_cosine = metrics["mean_cosine"]
 
+            # Atomic partial-state dump for tournament timeout recovery (T1).
+            # Mirrors the student-side schema; no productness val split on
+            # DINO yet, so train-side stats are reported under both keys.
+            import json as _json
+            progress_payload = {
+                "status": "in_progress",
+                "version": "v2",
+                "is_partial": True,
+                "epochs_completed": int(epoch),
+                "max_epochs": int(EPOCHS),
+                "combined_metric": float(metrics["combined"]),
+                "best_combined": float(max(best_combined, metrics["combined"])),
+                "recall_at_1": float(current_recall),
+                "recall_at_5": float(metrics.get("recall@5", 0.0)),
+                "mean_cosine": float(current_cosine),
+                "productness_loss": float(stats.get("productness_loss", 0.0)),
+                "productness_acc": float(stats.get("productness_acc", 0.0)),
+                "productness_pos_acc": float(stats.get("productness_pos_acc", 0.0)),
+                "productness_neg_acc": float(stats.get("productness_neg_acc", 0.0)),
+            }
+            progress_path = Path(ADAPTER_OUTPUT_DIR).parent / "metrics_progress_v2.json"
+            progress_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = progress_path.with_suffix(".json.tmp")
+            tmp.write_text(_json.dumps(progress_payload, indent=2))
+            tmp.replace(progress_path)
+
             is_collapsed = current_cosine > EARLY_STOP_COSINE_THRESHOLD
             if is_collapsed:
                 collapse_counter += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ description = "Autonomous pretraining research swarm"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "anthropic>=0.40.0",
     "einops>=0.8.0",
     "kernels>=0.11.7",
     "matplotlib>=3.10.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Autonomous pretraining research swarm"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "anthropic>=0.40.0",
     "einops>=0.8.0",
     "kernels>=0.11.7",
     "matplotlib>=3.10.8",

--- a/research_loop/agents/__init__.py
+++ b/research_loop/agents/__init__.py
@@ -12,6 +12,20 @@ All three share a single AgentClient (Anthropic SDK wrapper with prompt
 caching enabled on system prompts) but never share messages.
 """
 
-from research_loop.agents.client import AgentClient
+from research_loop.agents.client import (
+    AgentClient,
+    ClaudeCliClient,
+    CodexCliClient,
+    HermesCliClient,
+    LLMClient,
+    make_llm_client,
+)
 
-__all__ = ["AgentClient"]
+__all__ = [
+    "AgentClient",  # backwards-compat alias for make_llm_client
+    "ClaudeCliClient",
+    "CodexCliClient",
+    "HermesCliClient",
+    "LLMClient",
+    "make_llm_client",
+]

--- a/research_loop/agents/__init__.py
+++ b/research_loop/agents/__init__.py
@@ -1,0 +1,17 @@
+"""LLM agent layer for the autoreason loop.
+
+Three roles, all separate single-shot calls (the autoreason "fresh agent"
+invariant — no shared message history between the Critic, Author B, and
+Synthesizer):
+
+  - critic.CriticAgent       — finds problems in the incumbent A
+  - author.AuthorBAgent      — produces a unified-diff patch for B
+  - synthesizer.SynthesizerAgent — produces a synthesis patch (AB)
+
+All three share a single AgentClient (Anthropic SDK wrapper with prompt
+caching enabled on system prompts) but never share messages.
+"""
+
+from research_loop.agents.client import AgentClient
+
+__all__ = ["AgentClient"]

--- a/research_loop/agents/author.py
+++ b/research_loop/agents/author.py
@@ -1,0 +1,139 @@
+"""AuthorBAgent — produces a unified-diff patch addressing the critic's findings.
+
+Per autoreason paper §2: the author sees A and the critique only — no
+drafting history. Output is a unified diff that `git apply --check` accepts.
+The system prompt explicitly forbids V1 file edits (defense in depth — the
+patch applicator also rejects them, but baking the rule into the prompt
+reduces wasted LLM calls and clearer audit trails).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from research_loop.agents.client import AgentClient
+from research_loop.targets._base import V1_FORBIDDEN_PATHS
+
+
+_FORBIDDEN_LIST = "\n".join(f"  - {p}" for p in V1_FORBIDDEN_PATHS)
+
+
+AUTHOR_B_SYSTEM_PROMPT = f"""You are a senior ML engineer revising a training script based on a structured critique.
+
+Your job: produce a unified diff that addresses the critique's identified problems. You will see the current trainer source (A) and a critique with concrete problems. You write the revision (B).
+
+Rules:
+
+1. Address each problem the critique identifies. If the critique says "No actionable problems", produce an empty diff (just the words "NO_PATCH" on its own line — see Output format below).
+
+2. Do not make changes outside the identified problems. No drive-by refactors, comment fixes, or "while I'm here" cleanup. Surgical changes only.
+
+3. Produce a SINGLE unified diff applicable via `git apply` from the repo root. Path style: `a/path/to/file.py` and `b/path/to/file.py`. Include `diff --git a/... b/...` headers and full hunk context (3 lines minimum).
+
+4. **NEVER edit any of these V1-protected files:**
+{_FORBIDDEN_LIST}
+
+   These files preserve V1 experiment history. Edits to them will be rejected before training runs and waste your effort. If the critique points at a problem in one of these files, your patch should modify the V2 trainer (train_v2.py / train_dino_v2.py) to work around the V1 issue, not fix it directly in V1.
+
+5. Prefer minimal changes. A 5-line patch that addresses one root cause beats a 50-line refactor. The smaller the diff, the easier to revert if the experiment fails.
+
+6. Don't change the trainer's CLI or top-level constants unless the critique specifically points at them. The tournament's job is to A/B/AB-test changes; sweeping rewrites defeat that.
+
+Output format. Return EXACTLY this structure:
+
+# Rationale
+One short paragraph (2-4 sentences) explaining what you changed and why, tied to specific items in the critique.
+
+# Diff
+```
+<unified diff goes here>
+```
+
+If the critique reports no actionable problems and you should not patch:
+
+# Rationale
+No changes proposed — incumbent is performing within expectations.
+
+# Diff
+NO_PATCH
+"""
+
+
+@dataclass(frozen=True)
+class PatchProposal:
+    rationale: str
+    diff: str  # unified diff text; empty string when NO_PATCH
+    raw: str   # full LLM response for audit
+
+
+_FENCE_RE = re.compile(r"```(?:diff)?\s*\n(?P<body>.*?)\n```", re.DOTALL)
+
+
+def _parse_patch_proposal(raw: str) -> PatchProposal:
+    """Pull `# Rationale` paragraph and the diff block out of the response."""
+    rationale = ""
+    diff = ""
+    section: str | None = None
+    rationale_lines: list[str] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# Rationale"):
+            section = "rationale"
+            continue
+        if stripped.startswith("# Diff"):
+            section = "diff"
+            continue
+        if section == "rationale" and stripped:
+            rationale_lines.append(stripped)
+    rationale = " ".join(rationale_lines)
+
+    # Diff: prefer fenced block; fall back to "NO_PATCH" sentinel
+    fence_match = _FENCE_RE.search(raw)
+    if fence_match:
+        diff_body = fence_match.group("body").strip()
+        diff = "" if diff_body.upper() == "NO_PATCH" else diff_body
+    else:
+        # Look for unfenced "NO_PATCH" sentinel after # Diff heading
+        if "NO_PATCH" in raw.split("# Diff", 1)[-1]:
+            diff = ""
+        else:
+            # No fence and no NO_PATCH — best-effort: take everything after `# Diff`
+            after = raw.split("# Diff", 1)[-1].strip()
+            diff = after.strip("`").strip()
+
+    return PatchProposal(rationale=rationale, diff=diff, raw=raw)
+
+
+class AuthorBAgent:
+    """Critic output + trainer source → unified-diff patch B."""
+
+    SYSTEM_PROMPT = AUTHOR_B_SYSTEM_PROMPT
+
+    def __init__(self, client: AgentClient) -> None:
+        self.client = client
+
+    def author(
+        self,
+        *,
+        trainer_source: str,
+        trainer_path: str,
+        critique_text: str,
+    ) -> PatchProposal:
+        """Single fresh-agent call. Returns parsed PatchProposal with raw text preserved.
+
+        `trainer_path` is the repo-relative path Author B should target in
+        the diff headers (e.g. "student_finetune/train_v2.py").
+        """
+        user = (
+            f"## Current trainer source ({trainer_path})\n"
+            f"```python\n{trainer_source}\n```\n\n"
+            "## Critique\n"
+            f"{critique_text}\n\n"
+            f"Produce the patch in the format specified by your system prompt. "
+            f"Diff paths must be `a/{trainer_path}` and `b/{trainer_path}`."
+        )
+        # Higher temperature on the author — encourage diverse revisions
+        # (autoreason paper uses 0.8 for author roles).
+        raw = self.client.call(self.SYSTEM_PROMPT, user, temperature=0.8)
+        return _parse_patch_proposal(raw)

--- a/research_loop/agents/author.py
+++ b/research_loop/agents/author.py
@@ -92,7 +92,7 @@ def _parse_patch_proposal(raw: str) -> PatchProposal:
     fence_match = _FENCE_RE.search(raw)
     if fence_match:
         diff_body = fence_match.group("body").strip()
-        diff = "" if diff_body.upper() == "NO_PATCH" else diff_body
+        diff = "" if diff_body.upper() == "NO_PATCH" else (diff_body + "\n")
     else:
         # Look for unfenced "NO_PATCH" sentinel after # Diff heading
         if "NO_PATCH" in raw.split("# Diff", 1)[-1]:
@@ -100,7 +100,8 @@ def _parse_patch_proposal(raw: str) -> PatchProposal:
         else:
             # No fence and no NO_PATCH — best-effort: take everything after `# Diff`
             after = raw.split("# Diff", 1)[-1].strip()
-            diff = after.strip("`").strip()
+            stripped = after.strip("`").strip()
+            diff = (stripped + "\n") if stripped else ""
 
     return PatchProposal(rationale=rationale, diff=diff, raw=raw)
 

--- a/research_loop/agents/author.py
+++ b/research_loop/agents/author.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-from research_loop.agents.client import AgentClient
+from research_loop.agents.client import LLMClient
 from research_loop.targets._base import V1_FORBIDDEN_PATHS
 
 
@@ -111,7 +111,7 @@ class AuthorBAgent:
 
     SYSTEM_PROMPT = AUTHOR_B_SYSTEM_PROMPT
 
-    def __init__(self, client: AgentClient) -> None:
+    def __init__(self, client: LLMClient) -> None:
         self.client = client
 
     def author(

--- a/research_loop/agents/client.py
+++ b/research_loop/agents/client.py
@@ -1,77 +1,112 @@
-"""Single-shared Anthropic SDK wrapper for autoreason agent calls.
+"""LLM client abstraction with multi-CLI support.
 
-Each `.call(system, user)` is a fresh single-shot Messages request — no chat
-history persisted across calls — so the autoreason "fresh agent" invariant
-holds even though all three roles share one client instance. The system block
-gets `cache_control: ephemeral` so the prompt cache amortizes the role's
-fixed instructions across passes within a 5-minute window.
+Per project decision 2026-04-25, autoreason calls go through one of the
+user's existing local CLIs (`hermes`, `claude`, `codex`) — not via raw API
+keys. This keeps auth, rate-limit handling, model selection, and provider
+routing in the user's already-configured tools instead of duplicating them
+in this repo.
 
-API key sources (first match wins):
-  1. ANTHROPIC_API_KEY environment variable
-  2. ~/.hermes/.env file (key = value lines), to align with the repo's
-     existing Hermes Agent integration
+Each CLI client subprocess-shells its CLI, sending a combined system+user
+prompt and returning stdout. All three roles (Critic / Author B /
+Synthesizer) share one client instance — the autoreason "fresh agent"
+invariant is preserved because each `.call()` is a one-shot subprocess
+with no shared state.
 
-Default model is `claude-sonnet-4-6` per SPEC §Tech stack — Sonnet 4.6
-is fast enough for hour-scale autoreason loops and capable enough on ML
-training code. Override per-instance via the `model` constructor arg.
+Selection (CLI flag → env → default):
+  --llm-cli {hermes|claude|codex}    explicit choice
+  AUTORESEARCH_LLM_CLI=hermes        env override
+  default: hermes (matches repo's existing autoresearch convention)
+
+Per-CLI model override:
+  --llm-model NAME                   passed through to whichever CLI
 """
 
 from __future__ import annotations
 
 import os
-from pathlib import Path
+import subprocess
+from abc import ABC, abstractmethod
+from typing import Literal
 
-import anthropic
+LlmCliName = Literal["hermes", "claude", "codex"]
+DEFAULT_CLI: LlmCliName = "hermes"
 
-DEFAULT_MODEL = "claude-sonnet-4-6"
-DEFAULT_MAX_TOKENS = 4096
-
-
-def _load_dotenv(path: Path) -> dict[str, str]:
-    """Tolerant .env parser — KEY=VALUE per line, # comments, no quotes magic."""
-    out: dict[str, str] = {}
-    if not path.exists():
-        return out
-    for raw in path.read_text().splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, _, val = line.partition("=")
-        out[key.strip()] = val.strip().strip('"').strip("'")
-    return out
+# How long to wait for one CLI invocation. Generous because some CLIs do
+# tool-calling internally and can take ~minutes per response. Caller can
+# override via the timeout kwarg.
+DEFAULT_CALL_TIMEOUT_SECONDS = 600.0
 
 
-def resolve_api_key() -> str:
-    """Find an Anthropic API key in env or in ~/.hermes/.env. Raise if missing."""
-    if (key := os.environ.get("ANTHROPIC_API_KEY")):
-        return key
-    hermes = _load_dotenv(Path.home() / ".hermes" / ".env")
-    if (key := hermes.get("ANTHROPIC_API_KEY")):
-        return key
-    raise RuntimeError(
-        "ANTHROPIC_API_KEY not found. Set the environment variable or "
-        "add it to ~/.hermes/.env. autoreason cannot run without LLM access."
+def _combine_prompt(system: str, user: str) -> str:
+    """Merge system + user into a single prompt for CLIs without separate system flags.
+
+    The XML-ish framing is robust across providers and models; CLIs that have
+    a native --system-prompt flag (claude) override this in their subclass.
+    """
+    return (
+        "<system_instructions>\n"
+        f"{system}\n"
+        "</system_instructions>\n\n"
+        "<user_request>\n"
+        f"{user}\n"
+        "</user_request>"
     )
 
 
-class AgentClient:
-    """Thin wrapper around `anthropic.Anthropic` for the three autoreason roles.
+class LLMClient(ABC):
+    """Abstract single-shot LLM caller. Each call() is independent — no history."""
 
-    Each `.call()` is a fresh single-shot — no chat history. System prompts
-    are sent with `cache_control: ephemeral` so repeated calls with the
-    same role-specific system text hit the cache.
+    name: str = "abstract"
+
+    @abstractmethod
+    def call(
+        self,
+        system: str,
+        user: str,
+        *,
+        temperature: float = 0.8,
+        max_tokens: int | None = None,
+        timeout: float | None = None,
+    ) -> str:
+        """Return the assistant text. May raise RuntimeError on CLI failure."""
+
+
+def _run(cmd: list[str], *, timeout: float, stdin: str | None = None) -> str:
+    """Run a subprocess; return stdout; raise RuntimeError with full context on failure."""
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=stdin,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"LLM CLI call timed out after {timeout}s: {' '.join(cmd[:3])}..."
+        ) from e
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"LLM CLI failed (exit {proc.returncode}): {' '.join(cmd[:3])}...\n"
+            f"stderr: {proc.stderr[-2000:]}"
+        )
+    return proc.stdout
+
+
+class HermesCliClient(LLMClient):
+    """`hermes chat -q PROMPT [-m MODEL] [--provider P]`.
+
+    Hermes is the repo's existing autoresearch driver; matches what
+    student_finetune/run_v2.sh already uses. Default provider 'auto' lets
+    Hermes pick.
     """
 
-    def __init__(
-        self,
-        *,
-        model: str = DEFAULT_MODEL,
-        max_tokens: int = DEFAULT_MAX_TOKENS,
-        api_key: str | None = None,
-    ) -> None:
+    name = "hermes"
+
+    def __init__(self, *, model: str | None = None, provider: str = "auto") -> None:
         self.model = model
-        self.max_tokens = max_tokens
-        self.client = anthropic.Anthropic(api_key=api_key or resolve_api_key())
+        self.provider = provider
 
     def call(
         self,
@@ -80,22 +115,122 @@ class AgentClient:
         *,
         temperature: float = 0.8,
         max_tokens: int | None = None,
+        timeout: float | None = None,
     ) -> str:
-        """Run one fresh-agent inference; return the raw assistant text.
+        prompt = _combine_prompt(system, user)
+        cmd = [
+            "hermes", "chat",
+            "-q", prompt,
+            "--yolo",            # skip interactive confirms
+            "--max-turns", "1",  # single-shot — no agentic looping inside hermes
+            "--ignore-rules",    # don't apply user-config rules to autoreason
+            "-Q",                # quiet (suppress banner / status output)
+        ]
+        if self.model is not None:
+            cmd += ["-m", self.model]
+        if self.provider:
+            cmd += ["--provider", self.provider]
+        return _run(cmd, timeout=timeout or DEFAULT_CALL_TIMEOUT_SECONDS).strip()
 
-        Per autoreason paper §2: temperature 0.8 for authors / synthesizer
-        (encourage diverse revisions); 0.3 for judges (consistent evaluation).
-        Caller picks the right value for its role.
-        """
-        response = self.client.messages.create(
-            model=self.model,
-            max_tokens=max_tokens or self.max_tokens,
-            system=[{
-                "type": "text",
-                "text": system,
-                "cache_control": {"type": "ephemeral"},
-            }],
-            messages=[{"role": "user", "content": user}],
-            temperature=temperature,
+
+class ClaudeCliClient(LLMClient):
+    """`claude -p ... --system-prompt ...`.
+
+    Uses Claude Code's `--print` non-interactive mode with a separate
+    --system-prompt flag (so the system text is properly framed, not
+    merged into user input).
+    """
+
+    name = "claude"
+
+    def __init__(self, *, model: str | None = None) -> None:
+        self.model = model
+
+    def call(
+        self,
+        system: str,
+        user: str,
+        *,
+        temperature: float = 0.8,
+        max_tokens: int | None = None,
+        timeout: float | None = None,
+    ) -> str:
+        cmd = [
+            "claude",
+            "-p", user,
+            "--system-prompt", system,
+            "--bare",                              # minimal mode, no auto-memory etc.
+            "--dangerously-skip-permissions",      # autoreason runs unattended
+        ]
+        if self.model is not None:
+            cmd += ["--model", self.model]
+        return _run(cmd, timeout=timeout or DEFAULT_CALL_TIMEOUT_SECONDS).strip()
+
+
+class CodexCliClient(LLMClient):
+    """`codex exec [PROMPT] [--config model=NAME]`.
+
+    Codex doesn't have a separate --system-prompt; we combine system + user
+    via _combine_prompt() and pass as the single argument. Model selection
+    via -c model=... config override.
+    """
+
+    name = "codex"
+
+    def __init__(self, *, model: str | None = None) -> None:
+        self.model = model
+
+    def call(
+        self,
+        system: str,
+        user: str,
+        *,
+        temperature: float = 0.8,
+        max_tokens: int | None = None,
+        timeout: float | None = None,
+    ) -> str:
+        prompt = _combine_prompt(system, user)
+        cmd = ["codex", "exec"]
+        if self.model is not None:
+            cmd += ["-c", f"model={self.model}"]
+        cmd += [prompt]
+        return _run(cmd, timeout=timeout or DEFAULT_CALL_TIMEOUT_SECONDS).strip()
+
+
+_REGISTRY: dict[str, type[LLMClient]] = {
+    "hermes": HermesCliClient,
+    "claude": ClaudeCliClient,
+    "codex":  CodexCliClient,
+}
+
+
+def make_llm_client(
+    cli: LlmCliName | None = None,
+    *,
+    model: str | None = None,
+    provider: str = "auto",
+) -> LLMClient:
+    """Factory: pick a CLI by name, env, or fall back to the default.
+
+    Selection order:
+      1. explicit `cli` arg
+      2. AUTORESEARCH_LLM_CLI environment variable
+      3. DEFAULT_CLI ("hermes")
+
+    `provider` is Hermes-specific; ignored by Claude / Codex clients.
+    """
+    chosen = cli or os.environ.get("AUTORESEARCH_LLM_CLI") or DEFAULT_CLI
+    if chosen not in _REGISTRY:
+        raise ValueError(
+            f"Unknown LLM CLI: {chosen!r}. "
+            f"Supported: {sorted(_REGISTRY)}."
         )
-        return next(block.text for block in response.content if block.type == "text")
+    cls = _REGISTRY[chosen]
+    if cls is HermesCliClient:
+        return HermesCliClient(model=model, provider=provider)
+    return cls(model=model)
+
+
+# Backwards-compat alias — older code imports `AgentClient`. Now an alias for
+# the factory so the existing imports keep working without churn.
+AgentClient = make_llm_client

--- a/research_loop/agents/client.py
+++ b/research_loop/agents/client.py
@@ -1,0 +1,101 @@
+"""Single-shared Anthropic SDK wrapper for autoreason agent calls.
+
+Each `.call(system, user)` is a fresh single-shot Messages request — no chat
+history persisted across calls — so the autoreason "fresh agent" invariant
+holds even though all three roles share one client instance. The system block
+gets `cache_control: ephemeral` so the prompt cache amortizes the role's
+fixed instructions across passes within a 5-minute window.
+
+API key sources (first match wins):
+  1. ANTHROPIC_API_KEY environment variable
+  2. ~/.hermes/.env file (key = value lines), to align with the repo's
+     existing Hermes Agent integration
+
+Default model is `claude-sonnet-4-6` per SPEC §Tech stack — Sonnet 4.6
+is fast enough for hour-scale autoreason loops and capable enough on ML
+training code. Override per-instance via the `model` constructor arg.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import anthropic
+
+DEFAULT_MODEL = "claude-sonnet-4-6"
+DEFAULT_MAX_TOKENS = 4096
+
+
+def _load_dotenv(path: Path) -> dict[str, str]:
+    """Tolerant .env parser — KEY=VALUE per line, # comments, no quotes magic."""
+    out: dict[str, str] = {}
+    if not path.exists():
+        return out
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        out[key.strip()] = val.strip().strip('"').strip("'")
+    return out
+
+
+def resolve_api_key() -> str:
+    """Find an Anthropic API key in env or in ~/.hermes/.env. Raise if missing."""
+    if (key := os.environ.get("ANTHROPIC_API_KEY")):
+        return key
+    hermes = _load_dotenv(Path.home() / ".hermes" / ".env")
+    if (key := hermes.get("ANTHROPIC_API_KEY")):
+        return key
+    raise RuntimeError(
+        "ANTHROPIC_API_KEY not found. Set the environment variable or "
+        "add it to ~/.hermes/.env. autoreason cannot run without LLM access."
+    )
+
+
+class AgentClient:
+    """Thin wrapper around `anthropic.Anthropic` for the three autoreason roles.
+
+    Each `.call()` is a fresh single-shot — no chat history. System prompts
+    are sent with `cache_control: ephemeral` so repeated calls with the
+    same role-specific system text hit the cache.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str = DEFAULT_MODEL,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        api_key: str | None = None,
+    ) -> None:
+        self.model = model
+        self.max_tokens = max_tokens
+        self.client = anthropic.Anthropic(api_key=api_key or resolve_api_key())
+
+    def call(
+        self,
+        system: str,
+        user: str,
+        *,
+        temperature: float = 0.8,
+        max_tokens: int | None = None,
+    ) -> str:
+        """Run one fresh-agent inference; return the raw assistant text.
+
+        Per autoreason paper §2: temperature 0.8 for authors / synthesizer
+        (encourage diverse revisions); 0.3 for judges (consistent evaluation).
+        Caller picks the right value for its role.
+        """
+        response = self.client.messages.create(
+            model=self.model,
+            max_tokens=max_tokens or self.max_tokens,
+            system=[{
+                "type": "text",
+                "text": system,
+                "cache_control": {"type": "ephemeral"},
+            }],
+            messages=[{"role": "user", "content": user}],
+            temperature=temperature,
+        )
+        return next(block.text for block in response.content if block.type == "text")

--- a/research_loop/agents/critic.py
+++ b/research_loop/agents/critic.py
@@ -1,0 +1,104 @@
+"""CriticAgent — surfaces problems in the incumbent training script.
+
+Per autoreason paper §2: critics find problems only, no fixes proposed.
+This separation is load-bearing — when the same agent both criticizes and
+fixes, it tends to invent flaws to satisfy the critique prompt (sycophancy).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from research_loop.agents.client import AgentClient
+
+
+CRITIC_SYSTEM_PROMPT = """You are a senior ML engineer reviewing a production retail-product re-identification training script and its recent experiment history. Your only job is to identify concrete problems — do not propose fixes.
+
+Your reviewing posture:
+  - Be specific. Reference exact symbols, line ranges, or metric values from the inputs.
+  - Be evidence-based. Tie each problem to something visible in the trainer source, the recent results_v2.tsv rows, or the recent Outcome metrics.
+  - Be honest about ambiguity. If a metric is plateauing but the code looks reasonable, say "plateau on metric X with no obvious code-side cause" rather than inventing a flaw.
+  - If the run is healthy, say so explicitly. "No actionable problems" is a valid critique.
+
+You will be given:
+  - The current trainer source file
+  - The last 30 rows of results_v2.tsv (round outcomes)
+  - The last 10 Outcome JSON records from history.jsonl
+
+Output format. Return a critique in this exact shape (Markdown headings preserved):
+
+# Summary
+One paragraph (2-4 sentences) describing the overall state — is the run healthy, plateauing, regressing, or showing some specific failure mode?
+
+# Problems
+- Problem 1: <concrete issue, with reference>
+- Problem 2: ...
+- ...
+
+If there are no actionable problems, write a single line under # Problems: "No actionable problems — incumbent is performing within expectations."
+
+Do not propose solutions. Do not include code. Do not speculate beyond what the inputs support."""
+
+
+@dataclass(frozen=True)
+class Critique:
+    summary: str
+    problems: list[str]
+    raw: str  # full LLM response for audit
+
+
+def _parse_critique(raw: str) -> Critique:
+    """Extract # Summary and # Problems sections from the LLM response."""
+    summary = ""
+    problems: list[str] = []
+    section: str | None = None
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# Summary"):
+            section = "summary"
+            continue
+        if stripped.startswith("# Problems"):
+            section = "problems"
+            continue
+        if not stripped:
+            continue
+        if section == "summary":
+            summary = (summary + " " + stripped).strip() if summary else stripped
+        elif section == "problems":
+            # Bulleted line — strip leading marker
+            if stripped.startswith(("- ", "* ", "• ")):
+                problems.append(stripped[2:].strip())
+            elif stripped[0:2].rstrip(".").isdigit():
+                problems.append(stripped.split(".", 1)[-1].strip())
+    return Critique(summary=summary, problems=problems, raw=raw)
+
+
+class CriticAgent:
+    """Reads trainer + history → surfaces concrete problems."""
+
+    SYSTEM_PROMPT = CRITIC_SYSTEM_PROMPT
+
+    def __init__(self, client: AgentClient) -> None:
+        self.client = client
+
+    def critique(
+        self,
+        *,
+        trainer_source: str,
+        results_tsv_tail: str,
+        recent_outcomes_json: str,
+    ) -> Critique:
+        """Single fresh-agent call. Returns parsed Critique with raw text preserved."""
+        user = (
+            "## Trainer source\n"
+            f"```python\n{trainer_source}\n```\n\n"
+            "## Recent results_v2.tsv (last 30 rows)\n"
+            f"```tsv\n{results_tsv_tail}\n```\n\n"
+            "## Recent Outcome records (last 10)\n"
+            f"```jsonl\n{recent_outcomes_json}\n```\n\n"
+            "Produce the critique in the format specified by your system prompt."
+        )
+        # Lower temperature for the critic — we want consistent problem-finding,
+        # not creative interpretation (autoreason paper §2 uses 0.3 for judges).
+        raw = self.client.call(self.SYSTEM_PROMPT, user, temperature=0.3)
+        return _parse_critique(raw)

--- a/research_loop/agents/critic.py
+++ b/research_loop/agents/critic.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from research_loop.agents.client import AgentClient
+from research_loop.agents.client import LLMClient
 
 
 CRITIC_SYSTEM_PROMPT = """You are a senior ML engineer reviewing a production retail-product re-identification training script and its recent experiment history. Your only job is to identify concrete problems — do not propose fixes.
@@ -78,7 +78,7 @@ class CriticAgent:
 
     SYSTEM_PROMPT = CRITIC_SYSTEM_PROMPT
 
-    def __init__(self, client: AgentClient) -> None:
+    def __init__(self, client: LLMClient) -> None:
         self.client = client
 
     def critique(

--- a/research_loop/agents/synthesizer.py
+++ b/research_loop/agents/synthesizer.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from research_loop.agents.client import AgentClient
+from research_loop.agents.client import LLMClient
 from research_loop.agents.author import (
     PatchProposal,
     _FENCE_RE,
@@ -104,7 +104,7 @@ class SynthesizerAgent:
 
     SYSTEM_PROMPT = SYNTHESIZER_SYSTEM_PROMPT
 
-    def __init__(self, client: AgentClient) -> None:
+    def __init__(self, client: LLMClient) -> None:
         self.client = client
 
     def synthesize(

--- a/research_loop/agents/synthesizer.py
+++ b/research_loop/agents/synthesizer.py
@@ -1,0 +1,126 @@
+"""SynthesizerAgent — produces AB by taking the strongest elements of A and B.
+
+Per autoreason paper §2: the synthesizer sees A and B with anonymized labels
+and no metric history. The point is to find a more conservative middle ground
+than B alone — half the change, restricted to the strongest part — without
+being biased by either side's prior performance numbers.
+
+Per project decision 2026-04-25 (SPEC §Open questions resolved): the
+synthesizer sees ONLY the patches, not metric history.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from research_loop.agents.client import AgentClient
+from research_loop.agents.author import (
+    PatchProposal,
+    _FENCE_RE,
+)
+from research_loop.targets._base import V1_FORBIDDEN_PATHS
+
+
+_FORBIDDEN_LIST = "\n".join(f"  - {p}" for p in V1_FORBIDDEN_PATHS)
+
+
+SYNTHESIZER_SYSTEM_PROMPT = f"""You are a senior ML engineer producing a conservative synthesis of two competing revisions to a training script.
+
+You will see two patches labeled X and Y (anonymized — you do not know which one was authored by the critic-driven revision and which is the do-nothing baseline). Your job is to produce a third patch (the synthesis) that takes the strongest elements of each but commits less aggressively than the more extensive of the two.
+
+Synthesis principles:
+
+1. Find the smallest subset of changes that preserves the most likely-correct mechanism. If X adds three changes and Y adds none, your synthesis might keep one of X's changes — the one with the clearest rationale — and drop the others.
+
+2. Halve magnitudes when possible. If X changes a weight from 0.02 to 0.10, your synthesis might propose 0.05.
+
+3. Prefer additions over removals. If X removes a feature, your synthesis is more likely to keep the feature but reduce its weight than to remove it.
+
+4. Be willing to produce an empty patch ("NO_PATCH") when X and Y are both empty, or when X's changes are too entangled to halve cleanly. The tournament treats no-op as a first-class option.
+
+5. **NEVER edit any of these V1-protected files:**
+{_FORBIDDEN_LIST}
+
+   Defense in depth — the patch applicator will reject V1 edits, but you should not produce them.
+
+6. Output a SINGLE unified diff applicable via `git apply` from the repo root. Path style: `a/path/to/file.py` and `b/path/to/file.py`.
+
+You do NOT see the patches' performance metrics. Synthesize on structure and risk, not on which one looked better in past runs.
+
+Output format. Return EXACTLY this structure:
+
+# Rationale
+One short paragraph (2-4 sentences) explaining what you kept from each side and what you halved or dropped.
+
+# Diff
+```
+<unified diff goes here>
+```
+
+If the synthesis would be empty:
+
+# Rationale
+Synthesis is empty — neither candidate proposes changes that combine cleanly at lower magnitude.
+
+# Diff
+NO_PATCH
+"""
+
+
+def _parse_synthesis(raw: str) -> PatchProposal:
+    """Same shape as AuthorBAgent's PatchProposal — uses the same parser."""
+    rationale = ""
+    section: str | None = None
+    rationale_lines: list[str] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# Rationale"):
+            section = "rationale"
+            continue
+        if stripped.startswith("# Diff"):
+            section = "diff"
+            continue
+        if section == "rationale" and stripped:
+            rationale_lines.append(stripped)
+    rationale = " ".join(rationale_lines)
+
+    fence_match = _FENCE_RE.search(raw)
+    if fence_match:
+        diff_body = fence_match.group("body").strip()
+        diff = "" if diff_body.upper() == "NO_PATCH" else diff_body
+    else:
+        if "NO_PATCH" in raw.split("# Diff", 1)[-1]:
+            diff = ""
+        else:
+            after = raw.split("# Diff", 1)[-1].strip()
+            diff = after.strip("`").strip()
+
+    return PatchProposal(rationale=rationale, diff=diff, raw=raw)
+
+
+class SynthesizerAgent:
+    """Two patches with anonymized labels → conservative synthesis patch (AB)."""
+
+    SYSTEM_PROMPT = SYNTHESIZER_SYSTEM_PROMPT
+
+    def __init__(self, client: AgentClient) -> None:
+        self.client = client
+
+    def synthesize(
+        self,
+        *,
+        patch_x: str,
+        patch_y: str,
+        trainer_path: str,
+    ) -> PatchProposal:
+        """Single fresh-agent call. Anonymized X / Y labels per autoreason §2."""
+        user = (
+            "## Patch X\n"
+            f"```\n{patch_x or 'NO_PATCH'}\n```\n\n"
+            "## Patch Y\n"
+            f"```\n{patch_y or 'NO_PATCH'}\n```\n\n"
+            f"Produce the synthesis patch in the format specified by your system prompt. "
+            f"Diff paths must be `a/{trainer_path}` and `b/{trainer_path}`."
+        )
+        raw = self.client.call(self.SYSTEM_PROMPT, user, temperature=0.8)
+        return _parse_synthesis(raw)

--- a/research_loop/agents/synthesizer.py
+++ b/research_loop/agents/synthesizer.py
@@ -87,13 +87,14 @@ def _parse_synthesis(raw: str) -> PatchProposal:
     fence_match = _FENCE_RE.search(raw)
     if fence_match:
         diff_body = fence_match.group("body").strip()
-        diff = "" if diff_body.upper() == "NO_PATCH" else diff_body
+        diff = "" if diff_body.upper() == "NO_PATCH" else (diff_body + "\n")
     else:
         if "NO_PATCH" in raw.split("# Diff", 1)[-1]:
             diff = ""
         else:
             after = raw.split("# Diff", 1)[-1].strip()
-            diff = after.strip("`").strip()
+            stripped = after.strip("`").strip()
+            diff = (stripped + "\n") if stripped else ""
 
     return PatchProposal(rationale=rationale, diff=diff, raw=raw)
 

--- a/research_loop/candidate.py
+++ b/research_loop/candidate.py
@@ -23,7 +23,7 @@ from typing import Iterator, Literal
 
 CandidateKind = Literal["A", "B", "AB"]
 TargetName = Literal["student_v2", "dino_v2"]
-RecordType = Literal["candidate", "outcome", "decision"]
+RecordType = Literal["candidate", "outcome", "decision", "critique", "patch_proposal", "synthesis"]
 
 REQUIRED_FIELDS: tuple[str, ...] = (
     "id",
@@ -135,11 +135,79 @@ class Decision:
         return cls(**data)
 
 
+@dataclass
+class CritiqueRecord:
+    """Audit record of one Critic LLM call."""
+
+    round_id: str
+    target: TargetName
+    pass_index: int
+    summary: str
+    problems: list[str]
+    raw: str  # full LLM response text
+    record_type: RecordType = "critique"
+    created_at: float = field(default_factory=time.time)
+
+    def to_jsonl(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True)
+
+    @classmethod
+    def from_jsonl(cls, line: str) -> "CritiqueRecord":
+        return cls(**json.loads(line))
+
+
+@dataclass
+class PatchProposalRecord:
+    """Audit record of one Author B LLM call."""
+
+    round_id: str
+    target: TargetName
+    pass_index: int
+    candidate_id: str  # the B candidate this patch is attached to
+    rationale: str
+    diff: str
+    raw: str
+    record_type: RecordType = "patch_proposal"
+    created_at: float = field(default_factory=time.time)
+
+    def to_jsonl(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True)
+
+    @classmethod
+    def from_jsonl(cls, line: str) -> "PatchProposalRecord":
+        return cls(**json.loads(line))
+
+
+@dataclass
+class SynthesisRecord:
+    """Audit record of one Synthesizer LLM call."""
+
+    round_id: str
+    target: TargetName
+    pass_index: int
+    candidate_id: str  # the AB candidate this synthesis is attached to
+    rationale: str
+    diff: str
+    raw: str
+    record_type: RecordType = "synthesis"
+    created_at: float = field(default_factory=time.time)
+
+    def to_jsonl(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True)
+
+    @classmethod
+    def from_jsonl(cls, line: str) -> "SynthesisRecord":
+        return cls(**json.loads(line))
+
+
 # ---------------------------------------------------------------------------
 # I/O helpers
 # ---------------------------------------------------------------------------
 
-def append_history(history_path: Path, record: "Candidate | Outcome | Decision") -> None:
+HistoryRecord = "Candidate | Outcome | Decision | CritiqueRecord | PatchProposalRecord | SynthesisRecord"
+
+
+def append_history(history_path: Path, record: HistoryRecord) -> None:
     history_path.parent.mkdir(parents=True, exist_ok=True)
     with history_path.open("a") as f:
         f.write(record.to_jsonl() + "\n")
@@ -182,6 +250,33 @@ def read_decisions(history_path: Path, round_id: str | None = None) -> Iterator[
             continue
         raw["deploy_failures"] = tuple(raw.get("deploy_failures", ()))
         yield Decision(**raw)
+
+
+def read_critiques(history_path: Path, round_id: str | None = None) -> Iterator[CritiqueRecord]:
+    for raw in _iter_records(history_path):
+        if raw.get("record_type") != "critique":
+            continue
+        if round_id is not None and raw.get("round_id") != round_id:
+            continue
+        yield CritiqueRecord(**raw)
+
+
+def read_patch_proposals(history_path: Path, round_id: str | None = None) -> Iterator[PatchProposalRecord]:
+    for raw in _iter_records(history_path):
+        if raw.get("record_type") != "patch_proposal":
+            continue
+        if round_id is not None and raw.get("round_id") != round_id:
+            continue
+        yield PatchProposalRecord(**raw)
+
+
+def read_syntheses(history_path: Path, round_id: str | None = None) -> Iterator[SynthesisRecord]:
+    for raw in _iter_records(history_path):
+        if raw.get("record_type") != "synthesis":
+            continue
+        if round_id is not None and raw.get("round_id") != round_id:
+            continue
+        yield SynthesisRecord(**raw)
 
 
 def find_candidate(history_path: Path, candidate_id: str) -> Candidate | None:

--- a/research_loop/patch.py
+++ b/research_loop/patch.py
@@ -1,0 +1,135 @@
+"""Apply / revert unified diffs via `git apply` for autoreason rounds.
+
+Every autoreason pass mutates the working tree (Author B's patch, then AB's
+synthesis), runs training, then must restore the tree exactly. Doing this
+through `git apply` + `git apply -R` instead of file-level edits gives us:
+
+  - Atomic apply: `git apply --check` runs first; if any hunk fails, nothing
+    is applied. No partial mutations to clean up.
+  - Reversible: `git apply -R` is the official inverse of `git apply` for
+    the same diff. Same patch in / same patch out.
+  - V2 safety: we parse the diff's file paths first and reject any that
+    match V1_FORBIDDEN_PATHS. The LLM Author B's system prompt also forbids
+    V1 edits, but defense in depth — never trust the LLM's word.
+  - No working-tree pollution between rounds: try/finally guarantees revert
+    even on training-side exceptions.
+
+Usage:
+    with apply_patch(diff_text, repo=Path("/path/to/repo")):
+        # working tree mutated; run training, eval, etc.
+        ...
+    # working tree restored, regardless of how the inner block exited.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from research_loop.targets._base import V1_FORBIDDEN_PATHS
+
+# Match unified-diff file headers: "+++ b/path/to/file" or "--- a/path/to/file"
+# and the "diff --git" line to be tolerant of `git diff` output.
+_DIFF_PATH_RE = re.compile(
+    r"^(?:\+\+\+ b/|--- a/|diff --git a/)(?P<path>\S+)",
+    re.MULTILINE,
+)
+
+
+def diff_touches_v1(diff_text: str) -> list[str]:
+    """Return the V1_FORBIDDEN_PATHS that this diff would modify (empty list = safe).
+
+    Parses the diff's file headers; any path matching V1_FORBIDDEN_PATHS
+    (suffix or exact) is reported. Designed to be called *before* `git apply`.
+    """
+    paths = {m.group("path") for m in _DIFF_PATH_RE.finditer(diff_text)}
+    # Strip the "b/" prefix on diff --git lines that captured the second path
+    paths = {p.removeprefix("b/") for p in paths}
+    forbidden_hits: list[str] = []
+    for p in paths:
+        for forbidden in V1_FORBIDDEN_PATHS:
+            if p == forbidden or p.endswith("/" + forbidden) or p.endswith(forbidden):
+                forbidden_hits.append(p)
+                break
+    return forbidden_hits
+
+
+def _git(args: list[str], *, cwd: Path, stdin: str | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git"] + args,
+        cwd=cwd,
+        input=stdin,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _check_clean_tree(repo: Path) -> None:
+    """Refuse to apply if the working tree has uncommitted changes —
+    we'd lose the user's work on revert."""
+    res = _git(["status", "--porcelain"], cwd=repo)
+    if res.returncode != 0:
+        raise RuntimeError(f"git status failed in {repo}: {res.stderr}")
+    if res.stdout.strip():
+        raise RuntimeError(
+            "Working tree is dirty; commit or stash before applying patches.\n"
+            f"git status:\n{res.stdout}"
+        )
+
+
+@contextmanager
+def apply_patch(diff_text: str, *, repo: Path, require_clean_tree: bool = True) -> Iterator[None]:
+    """Apply a unified diff; revert on context exit.
+
+    Raises ValueError if the diff touches V1_FORBIDDEN_PATHS (no mutation).
+    Raises subprocess.CalledProcessError if git apply --check rejects the
+    diff (malformed, conflicts, etc.) — also no mutation.
+    """
+    if not diff_text.strip():
+        # Empty diff = no-op (matches kind="A" do-nothing semantics)
+        yield
+        return
+
+    forbidden = diff_touches_v1(diff_text)
+    if forbidden:
+        raise ValueError(
+            f"Patch touches V1_FORBIDDEN_PATHS files: {forbidden}. "
+            f"Tournament patches must only modify V2 files."
+        )
+
+    if require_clean_tree:
+        _check_clean_tree(repo)
+
+    # Validate before mutating — `git apply --check` exits non-zero on conflict.
+    check = _git(["apply", "--check"], cwd=repo, stdin=diff_text)
+    if check.returncode != 0:
+        raise subprocess.CalledProcessError(
+            returncode=check.returncode,
+            cmd=["git", "apply", "--check"],
+            output=check.stdout,
+            stderr=check.stderr,
+        )
+
+    apply_res = _git(["apply"], cwd=repo, stdin=diff_text)
+    if apply_res.returncode != 0:  # pragma: no cover — should be caught by --check
+        raise subprocess.CalledProcessError(
+            returncode=apply_res.returncode,
+            cmd=["git", "apply"],
+            output=apply_res.stdout,
+            stderr=apply_res.stderr,
+        )
+
+    try:
+        yield
+    finally:
+        revert = _git(["apply", "-R"], cwd=repo, stdin=diff_text)
+        if revert.returncode != 0:  # pragma: no cover — surfaces the bug, doesn't swallow
+            raise RuntimeError(
+                f"Patch revert failed; working tree may be dirty.\n"
+                f"stderr: {revert.stderr}\n"
+                f"Original patch:\n{diff_text}"
+            )

--- a/research_loop/promote.py
+++ b/research_loop/promote.py
@@ -52,6 +52,10 @@ class CandidateResult:
     # when both A and the challenger expose the field.
     productness_pos_acc: float | None = None
     productness_neg_acc: float | None = None
+    # Status from TrainOutcome. "timeout" candidates cannot be promoted —
+    # we don't trust partial metrics for production-track decisions even
+    # if they happen to look good.
+    status: str = "success"
 
 
 @dataclass(frozen=True)
@@ -96,6 +100,8 @@ def decide(results: list[CandidateResult]) -> Decision:
     best_reason = "no challengers; incumbent A wins by default"
 
     for c in challengers:
+        if c.status != "success":
+            continue  # vetoed: timeout / failed candidates cannot be promoted
         if not c.has_rollback:
             continue  # vetoed: non-A without rollback
         delta = c.combined - a.combined

--- a/research_loop/targets/_base.py
+++ b/research_loop/targets/_base.py
@@ -80,20 +80,28 @@ class TargetAdapter:
             return
         assert_no_v1_writes(candidate.changed_files)
 
+    @property
+    def METRICS_PROGRESS_JSON(self) -> Path:
+        """Sibling of METRICS_JSON; trainers write this after every eval cycle."""
+        return self.METRICS_JSON.parent / "metrics_progress_v2.json"
+
+    SIGTERM_GRACE_SECONDS: float = 30.0
+
     def train(
         self,
         candidate: Candidate,
         max_epochs: int | None = None,
         dry_run: bool = False,
         log_path: Path | None = None,
+        max_seconds: float | None = None,
     ) -> TrainOutcome:
         """Run the training subprocess and return a TrainOutcome.
 
-        For kind='A' (do-nothing baseline) on the *first* round, this still
-        executes a real training run because the baseline metrics need to
-        come from somewhere. For subsequent rounds where A is just "the
-        incumbent we already evaluated", callers should skip executing A
-        and reuse its prior outcome.
+        Time budget: when `max_seconds` is set, the subprocess is killed
+        cleanly (SIGTERM, 30s grace, then SIGKILL) on overrun. Whatever
+        progress was written to `metrics_progress_v2.json` up to that point
+        is parsed; status becomes "timeout". promote.decide() rejects timeout
+        candidates regardless of partial-metric values.
         """
         epochs = max_epochs if max_epochs is not None else self.DEFAULT_EPOCHS
         cmd = list(self.TRAIN_CMD) + ["--max-epochs", str(epochs)]
@@ -113,20 +121,39 @@ class TargetAdapter:
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
         t0 = time.time()
+        timed_out = False
         with log_path.open("w") as logf:
-            proc = subprocess.run(
-                cmd,
-                cwd=self.REPO_DIR,
-                stdout=logf,
-                stderr=subprocess.STDOUT,
-                check=False,
+            proc = subprocess.Popen(
+                cmd, cwd=self.REPO_DIR,
+                stdout=logf, stderr=subprocess.STDOUT,
             )
+            try:
+                proc.wait(timeout=max_seconds)
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                proc.terminate()
+                try:
+                    proc.wait(timeout=self.SIGTERM_GRACE_SECONDS)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    try:
+                        proc.wait(timeout=10.0)
+                    except subprocess.TimeoutExpired:
+                        pass
         elapsed = time.time() - t0
 
         from research_loop.evaluators import parse_metrics  # local import: avoid cycle
         metrics: dict[str, float] = {}
         status = "failed"
-        if proc.returncode == 0 and self.METRICS_JSON.exists():
+        if timed_out:
+            status = "timeout"
+            # Recover whatever the trainer wrote up to its last eval (may be empty)
+            if self.METRICS_PROGRESS_JSON.exists():
+                try:
+                    metrics = parse_metrics(self.METRICS_PROGRESS_JSON)
+                except Exception:
+                    metrics = {}
+        elif proc.returncode == 0 and self.METRICS_JSON.exists():
             try:
                 metrics = parse_metrics(self.METRICS_JSON)
                 status = "success"

--- a/research_loop/tests/test_agent_client.py
+++ b/research_loop/tests/test_agent_client.py
@@ -1,0 +1,131 @@
+"""T4 verification: AgentClient wrapper.
+
+No real Anthropic API call — we mock at the SDK boundary. Verifies:
+  - request shape (system block has cache_control: ephemeral)
+  - no message history persisted across calls (fresh-agent invariant)
+  - API key resolves from env, then from ~/.hermes/.env
+  - missing key raises a clear error
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from research_loop.agents.client import (
+    AgentClient,
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_MODEL,
+    resolve_api_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# API key resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_api_key_from_env(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-from-env")
+    assert resolve_api_key() == "sk-from-env"
+
+
+def test_resolve_api_key_falls_back_to_hermes_env(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    (fake_home / ".hermes").mkdir()
+    (fake_home / ".hermes" / ".env").write_text(
+        "# comment line\n"
+        "ANTHROPIC_API_KEY=sk-from-hermes\n"
+        "OTHER=ignored\n"
+    )
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    assert resolve_api_key() == "sk-from-hermes"
+
+
+def test_resolve_api_key_handles_quoted_values(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    (fake_home / ".hermes").mkdir()
+    (fake_home / ".hermes" / ".env").write_text('ANTHROPIC_API_KEY="sk-quoted"\n')
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    assert resolve_api_key() == "sk-quoted"
+
+
+def test_resolve_api_key_missing_raises(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)  # no .hermes/.env
+    with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY not found"):
+        resolve_api_key()
+
+
+# ---------------------------------------------------------------------------
+# AgentClient request shape
+# ---------------------------------------------------------------------------
+
+@patch("research_loop.agents.client.anthropic.Anthropic")
+def test_call_sends_system_block_with_cache_control(mock_anthropic_cls):
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(type="text", text="response text")]
+    mock_client.messages.create.return_value = mock_response
+    mock_anthropic_cls.return_value = mock_client
+
+    client = AgentClient(api_key="sk-test")
+    out = client.call("system text", "user text", temperature=0.5)
+
+    assert out == "response text"
+    call_kwargs = mock_client.messages.create.call_args.kwargs
+    assert call_kwargs["model"] == DEFAULT_MODEL
+    assert call_kwargs["max_tokens"] == DEFAULT_MAX_TOKENS
+    assert call_kwargs["temperature"] == 0.5
+    # System block: list with one text block + cache_control ephemeral
+    sys_block = call_kwargs["system"]
+    assert isinstance(sys_block, list) and len(sys_block) == 1
+    assert sys_block[0]["type"] == "text"
+    assert sys_block[0]["text"] == "system text"
+    assert sys_block[0]["cache_control"] == {"type": "ephemeral"}
+    # Messages: just the one user turn — no chat history
+    assert call_kwargs["messages"] == [{"role": "user", "content": "user text"}]
+
+
+@patch("research_loop.agents.client.anthropic.Anthropic")
+def test_call_does_not_persist_history_across_calls(mock_anthropic_cls):
+    """Fresh-agent invariant: each call sends only its own user turn,
+    not accumulated history from prior calls."""
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(type="text", text="r")]
+    mock_client.messages.create.return_value = mock_response
+    mock_anthropic_cls.return_value = mock_client
+
+    client = AgentClient(api_key="sk-test")
+    client.call("sys", "user1")
+    client.call("sys", "user2")
+    client.call("sys", "user3")
+
+    # Each create() call should have exactly ONE message — the current user turn
+    for call in mock_client.messages.create.call_args_list:
+        assert len(call.kwargs["messages"]) == 1
+
+
+@patch("research_loop.agents.client.anthropic.Anthropic")
+def test_call_max_tokens_override(mock_anthropic_cls):
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(type="text", text="r")]
+    mock_client.messages.create.return_value = mock_response
+    mock_anthropic_cls.return_value = mock_client
+
+    client = AgentClient(api_key="sk-test", max_tokens=2048)
+    client.call("sys", "user", max_tokens=8192)
+    assert mock_client.messages.create.call_args.kwargs["max_tokens"] == 8192
+
+
+@patch("research_loop.agents.client.anthropic.Anthropic")
+def test_default_model_is_sonnet_4_6(mock_anthropic_cls):
+    """SPEC §Tech stack pins Sonnet 4.6 for all three agent roles."""
+    assert DEFAULT_MODEL == "claude-sonnet-4-6"

--- a/research_loop/tests/test_agent_client.py
+++ b/research_loop/tests/test_agent_client.py
@@ -1,131 +1,200 @@
-"""T4 verification: AgentClient wrapper.
+"""T4 verification: CLI-backed LLM clients (hermes / claude / codex).
 
-No real Anthropic API call — we mock at the SDK boundary. Verifies:
-  - request shape (system block has cache_control: ephemeral)
-  - no message history persisted across calls (fresh-agent invariant)
-  - API key resolves from env, then from ~/.hermes/.env
-  - missing key raises a clear error
+No real CLI invocation — we mock subprocess.run at the boundary. Verifies:
+  - factory dispatch by name + AUTORESEARCH_LLM_CLI env override
+  - each CLI's command-line shape (correct flags, model passthrough)
+  - fresh-agent invariant (each .call() is one independent subprocess)
+  - timeout / non-zero exit are surfaced as clear RuntimeErrors
 """
 
 from __future__ import annotations
 
-from pathlib import Path
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from research_loop.agents.client import (
-    AgentClient,
-    DEFAULT_MAX_TOKENS,
-    DEFAULT_MODEL,
-    resolve_api_key,
+    DEFAULT_CLI,
+    ClaudeCliClient,
+    CodexCliClient,
+    HermesCliClient,
+    make_llm_client,
 )
 
 
-# ---------------------------------------------------------------------------
-# API key resolution
-# ---------------------------------------------------------------------------
-
-def test_resolve_api_key_from_env(monkeypatch):
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-from-env")
-    assert resolve_api_key() == "sk-from-env"
-
-
-def test_resolve_api_key_falls_back_to_hermes_env(monkeypatch, tmp_path: Path):
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    fake_home = tmp_path / "home"
-    fake_home.mkdir()
-    (fake_home / ".hermes").mkdir()
-    (fake_home / ".hermes" / ".env").write_text(
-        "# comment line\n"
-        "ANTHROPIC_API_KEY=sk-from-hermes\n"
-        "OTHER=ignored\n"
-    )
-    monkeypatch.setattr(Path, "home", lambda: fake_home)
-    assert resolve_api_key() == "sk-from-hermes"
-
-
-def test_resolve_api_key_handles_quoted_values(monkeypatch, tmp_path: Path):
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    fake_home = tmp_path / "home"
-    fake_home.mkdir()
-    (fake_home / ".hermes").mkdir()
-    (fake_home / ".hermes" / ".env").write_text('ANTHROPIC_API_KEY="sk-quoted"\n')
-    monkeypatch.setattr(Path, "home", lambda: fake_home)
-    assert resolve_api_key() == "sk-quoted"
-
-
-def test_resolve_api_key_missing_raises(monkeypatch, tmp_path: Path):
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)  # no .hermes/.env
-    with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY not found"):
-        resolve_api_key()
+def _ok(stdout: str, stderr: str = "") -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = 0
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc
 
 
 # ---------------------------------------------------------------------------
-# AgentClient request shape
+# Factory selection
 # ---------------------------------------------------------------------------
 
-@patch("research_loop.agents.client.anthropic.Anthropic")
-def test_call_sends_system_block_with_cache_control(mock_anthropic_cls):
-    mock_client = MagicMock()
-    mock_response = MagicMock()
-    mock_response.content = [MagicMock(type="text", text="response text")]
-    mock_client.messages.create.return_value = mock_response
-    mock_anthropic_cls.return_value = mock_client
-
-    client = AgentClient(api_key="sk-test")
-    out = client.call("system text", "user text", temperature=0.5)
-
-    assert out == "response text"
-    call_kwargs = mock_client.messages.create.call_args.kwargs
-    assert call_kwargs["model"] == DEFAULT_MODEL
-    assert call_kwargs["max_tokens"] == DEFAULT_MAX_TOKENS
-    assert call_kwargs["temperature"] == 0.5
-    # System block: list with one text block + cache_control ephemeral
-    sys_block = call_kwargs["system"]
-    assert isinstance(sys_block, list) and len(sys_block) == 1
-    assert sys_block[0]["type"] == "text"
-    assert sys_block[0]["text"] == "system text"
-    assert sys_block[0]["cache_control"] == {"type": "ephemeral"}
-    # Messages: just the one user turn — no chat history
-    assert call_kwargs["messages"] == [{"role": "user", "content": "user text"}]
+def test_default_cli_is_hermes():
+    assert DEFAULT_CLI == "hermes"
 
 
-@patch("research_loop.agents.client.anthropic.Anthropic")
-def test_call_does_not_persist_history_across_calls(mock_anthropic_cls):
-    """Fresh-agent invariant: each call sends only its own user turn,
-    not accumulated history from prior calls."""
-    mock_client = MagicMock()
-    mock_response = MagicMock()
-    mock_response.content = [MagicMock(type="text", text="r")]
-    mock_client.messages.create.return_value = mock_response
-    mock_anthropic_cls.return_value = mock_client
-
-    client = AgentClient(api_key="sk-test")
-    client.call("sys", "user1")
-    client.call("sys", "user2")
-    client.call("sys", "user3")
-
-    # Each create() call should have exactly ONE message — the current user turn
-    for call in mock_client.messages.create.call_args_list:
-        assert len(call.kwargs["messages"]) == 1
+def test_factory_uses_explicit_arg(monkeypatch):
+    monkeypatch.delenv("AUTORESEARCH_LLM_CLI", raising=False)
+    assert isinstance(make_llm_client("claude"), ClaudeCliClient)
+    assert isinstance(make_llm_client("codex"), CodexCliClient)
+    assert isinstance(make_llm_client("hermes"), HermesCliClient)
 
 
-@patch("research_loop.agents.client.anthropic.Anthropic")
-def test_call_max_tokens_override(mock_anthropic_cls):
-    mock_client = MagicMock()
-    mock_response = MagicMock()
-    mock_response.content = [MagicMock(type="text", text="r")]
-    mock_client.messages.create.return_value = mock_response
-    mock_anthropic_cls.return_value = mock_client
-
-    client = AgentClient(api_key="sk-test", max_tokens=2048)
-    client.call("sys", "user", max_tokens=8192)
-    assert mock_client.messages.create.call_args.kwargs["max_tokens"] == 8192
+def test_factory_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("AUTORESEARCH_LLM_CLI", "claude")
+    assert isinstance(make_llm_client(None), ClaudeCliClient)
 
 
-@patch("research_loop.agents.client.anthropic.Anthropic")
-def test_default_model_is_sonnet_4_6(mock_anthropic_cls):
-    """SPEC §Tech stack pins Sonnet 4.6 for all three agent roles."""
-    assert DEFAULT_MODEL == "claude-sonnet-4-6"
+def test_factory_falls_back_to_default(monkeypatch):
+    monkeypatch.delenv("AUTORESEARCH_LLM_CLI", raising=False)
+    assert isinstance(make_llm_client(None), HermesCliClient)
+
+
+def test_factory_rejects_unknown_cli(monkeypatch):
+    monkeypatch.delenv("AUTORESEARCH_LLM_CLI", raising=False)
+    with pytest.raises(ValueError, match="Unknown LLM CLI"):
+        make_llm_client("totally-bogus")
+
+
+def test_factory_threads_model_to_hermes():
+    client = make_llm_client("hermes", model="anthropic/claude-sonnet-4")
+    assert isinstance(client, HermesCliClient)
+    assert client.model == "anthropic/claude-sonnet-4"
+
+
+def test_factory_threads_model_to_claude():
+    client = make_llm_client("claude", model="claude-sonnet-4-6")
+    assert client.model == "claude-sonnet-4-6"
+
+
+# ---------------------------------------------------------------------------
+# HermesCliClient
+# ---------------------------------------------------------------------------
+
+@patch("research_loop.agents.client.subprocess.run")
+def test_hermes_call_passes_combined_prompt_and_flags(mock_run):
+    mock_run.return_value = _ok("hermes response text\n")
+    client = HermesCliClient(model="anthropic/claude-sonnet-4", provider="anthropic")
+    out = client.call("system text", "user text")
+
+    assert out == "hermes response text"
+    cmd = mock_run.call_args.args[0]
+    assert cmd[0:2] == ["hermes", "chat"]
+    assert "-q" in cmd
+    prompt = cmd[cmd.index("-q") + 1]
+    assert "system text" in prompt
+    assert "user text" in prompt
+    assert "--max-turns" in cmd and "1" == cmd[cmd.index("--max-turns") + 1]
+    assert "-m" in cmd and "anthropic/claude-sonnet-4" == cmd[cmd.index("-m") + 1]
+    assert "--provider" in cmd and "anthropic" == cmd[cmd.index("--provider") + 1]
+    assert "--yolo" in cmd
+    # No chat history input — single shot
+    assert mock_run.call_args.kwargs.get("input") is None
+
+
+@patch("research_loop.agents.client.subprocess.run")
+def test_hermes_call_without_model_omits_flag(mock_run):
+    mock_run.return_value = _ok("text")
+    client = HermesCliClient()
+    client.call("sys", "user")
+    cmd = mock_run.call_args.args[0]
+    assert "-m" not in cmd  # no model override
+
+
+# ---------------------------------------------------------------------------
+# ClaudeCliClient
+# ---------------------------------------------------------------------------
+
+@patch("research_loop.agents.client.subprocess.run")
+def test_claude_call_uses_native_system_prompt_flag(mock_run):
+    mock_run.return_value = _ok("claude response\n")
+    client = ClaudeCliClient(model="claude-sonnet-4-6")
+    out = client.call("system text", "user text")
+
+    assert out == "claude response"
+    cmd = mock_run.call_args.args[0]
+    assert cmd[0] == "claude"
+    assert "-p" in cmd and "user text" == cmd[cmd.index("-p") + 1]
+    assert "--system-prompt" in cmd and "system text" == cmd[cmd.index("--system-prompt") + 1]
+    assert "--bare" in cmd
+    assert "--dangerously-skip-permissions" in cmd
+    assert "--model" in cmd and "claude-sonnet-4-6" == cmd[cmd.index("--model") + 1]
+
+
+# ---------------------------------------------------------------------------
+# CodexCliClient
+# ---------------------------------------------------------------------------
+
+@patch("research_loop.agents.client.subprocess.run")
+def test_codex_call_uses_combined_prompt_and_config_override(mock_run):
+    mock_run.return_value = _ok("codex response\n")
+    client = CodexCliClient(model="gpt-5")
+    out = client.call("system text", "user text")
+
+    assert out == "codex response"
+    cmd = mock_run.call_args.args[0]
+    assert cmd[:2] == ["codex", "exec"]
+    # Model passed via -c key=value override
+    assert "-c" in cmd and "model=gpt-5" == cmd[cmd.index("-c") + 1]
+    # Combined prompt is the trailing arg
+    last = cmd[-1]
+    assert "system text" in last
+    assert "user text" in last
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+@patch("research_loop.agents.client.subprocess.run")
+def test_non_zero_exit_raises_runtime_error_with_stderr(mock_run):
+    proc = MagicMock()
+    proc.returncode = 2
+    proc.stdout = ""
+    proc.stderr = "rate limit hit"
+    mock_run.return_value = proc
+
+    client = HermesCliClient()
+    with pytest.raises(RuntimeError, match="rate limit hit"):
+        client.call("sys", "user")
+
+
+@patch("research_loop.agents.client.subprocess.run")
+def test_timeout_raises_runtime_error(mock_run):
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["hermes"], timeout=5)
+    client = HermesCliClient()
+    with pytest.raises(RuntimeError, match="timed out"):
+        client.call("sys", "user", timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Fresh-agent invariant across roles
+# ---------------------------------------------------------------------------
+
+@patch("research_loop.agents.client.subprocess.run")
+def test_each_call_is_independent_subprocess(mock_run):
+    """No shared state across .call() invocations — each is its own subprocess."""
+    mock_run.return_value = _ok("response")
+    client = HermesCliClient()
+
+    client.call("sys1", "user1")
+    client.call("sys2", "user2")
+    client.call("sys3", "user3")
+
+    assert mock_run.call_count == 3
+    # Each call's prompt embeds its own system+user — no accumulated history
+    for call, expected_sys, expected_user in zip(
+        mock_run.call_args_list,
+        ["sys1", "sys2", "sys3"],
+        ["user1", "user2", "user3"],
+    ):
+        cmd = call.args[0]
+        prompt = cmd[cmd.index("-q") + 1]
+        assert expected_sys in prompt
+        assert expected_user in prompt

--- a/research_loop/tests/test_agents.py
+++ b/research_loop/tests/test_agents.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from research_loop.agents.author import AuthorBAgent, PatchProposal, _parse_patch_proposal
-from research_loop.agents.client import AgentClient
+from research_loop.agents.client import LLMClient
 from research_loop.agents.critic import Critique, CriticAgent, _parse_critique
 from research_loop.agents.synthesizer import SynthesizerAgent, _parse_synthesis
 
@@ -51,7 +51,7 @@ def test_parse_critique_no_actionable_problems():
 
 
 def test_critic_agent_calls_client_with_low_temperature():
-    mock_client = MagicMock(spec=AgentClient)
+    mock_client = MagicMock(spec=LLMClient)
     mock_client.call.return_value = CRITIC_RESPONSE_SAMPLE
     agent = CriticAgent(mock_client)
     out = agent.critique(
@@ -126,7 +126,7 @@ def test_author_agent_system_prompt_forbids_v1_edits():
 
 
 def test_author_agent_calls_client_with_higher_temperature():
-    mock_client = MagicMock(spec=AgentClient)
+    mock_client = MagicMock(spec=LLMClient)
     mock_client.call.return_value = AUTHOR_B_RESPONSE_SAMPLE
     agent = AuthorBAgent(mock_client)
     out = agent.author(
@@ -167,7 +167,7 @@ def test_parse_synthesis_extracts_rationale_and_diff():
 
 def test_synthesizer_uses_anonymized_labels_in_user_message():
     """Per autoreason paper §2: synthesizer sees X / Y, not A / B."""
-    mock_client = MagicMock(spec=AgentClient)
+    mock_client = MagicMock(spec=LLMClient)
     mock_client.call.return_value = SYNTH_RESPONSE_SAMPLE
     agent = SynthesizerAgent(mock_client)
     agent.synthesize(
@@ -185,7 +185,7 @@ def test_synthesizer_uses_anonymized_labels_in_user_message():
 
 def test_synthesizer_does_not_see_metrics():
     """Per project decision 2026-04-25: synthesizer sees only patches, no metric history."""
-    mock_client = MagicMock(spec=AgentClient)
+    mock_client = MagicMock(spec=LLMClient)
     mock_client.call.return_value = SYNTH_RESPONSE_SAMPLE
     agent = SynthesizerAgent(mock_client)
     agent.synthesize(
@@ -209,7 +209,7 @@ def test_three_agents_make_three_independent_calls():
     Each .critique() / .author() / .synthesize() call invokes
     AgentClient.call exactly once with a fresh user message.
     """
-    mock_client = MagicMock(spec=AgentClient)
+    mock_client = MagicMock(spec=LLMClient)
     mock_client.call.side_effect = [
         CRITIC_RESPONSE_SAMPLE,
         AUTHOR_B_RESPONSE_SAMPLE,

--- a/research_loop/tests/test_agents.py
+++ b/research_loop/tests/test_agents.py
@@ -1,0 +1,240 @@
+"""T5 verification: Critic / Author B / Synthesizer agents.
+
+Mocked AgentClient.call — no real LLM hits. Verifies parsing, fresh-agent
+invariant (each call is single-shot, no history mutation), V1-safety prompt
+language, and that author/synthesizer outputs are valid unified diffs.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from research_loop.agents.author import AuthorBAgent, PatchProposal, _parse_patch_proposal
+from research_loop.agents.client import AgentClient
+from research_loop.agents.critic import Critique, CriticAgent, _parse_critique
+from research_loop.agents.synthesizer import SynthesizerAgent, _parse_synthesis
+
+
+# ---------------------------------------------------------------------------
+# CriticAgent
+# ---------------------------------------------------------------------------
+
+CRITIC_RESPONSE_SAMPLE = """# Summary
+The student trainer is plateauing on combined around 0.79 with productness neg_acc stuck at 0.76 across the last three epochs.
+
+# Problems
+- The productness BCE weight may be too low to drive meaningful gradient through the head; pos_acc is already saturated near 1.0 while neg_acc has not improved since epoch 1.
+- The strong-aug RandomErasing (p=0.2) may be erasing salient features in commodity images, given the unlabeled commodity ratio of 15%.
+- No early stopping on productness_neg_acc — the run will burn 30 epochs even when retrieval has already converged.
+"""
+
+
+def test_parse_critique_extracts_summary_and_problems():
+    critique = _parse_critique(CRITIC_RESPONSE_SAMPLE)
+    assert "plateauing" in critique.summary.lower()
+    assert len(critique.problems) == 3
+    assert "productness BCE weight" in critique.problems[0]
+    assert critique.raw == CRITIC_RESPONSE_SAMPLE
+
+
+def test_parse_critique_no_actionable_problems():
+    raw = (
+        "# Summary\nRun is healthy.\n\n"
+        "# Problems\nNo actionable problems — incumbent is performing within expectations."
+    )
+    critique = _parse_critique(raw)
+    assert critique.summary == "Run is healthy."
+    # Sentence is captured as one bullet-less line — that's fine; check raw is preserved
+    assert critique.raw == raw
+
+
+def test_critic_agent_calls_client_with_low_temperature():
+    mock_client = MagicMock(spec=AgentClient)
+    mock_client.call.return_value = CRITIC_RESPONSE_SAMPLE
+    agent = CriticAgent(mock_client)
+    out = agent.critique(
+        trainer_source="def main(): pass",
+        results_tsv_tail="round_id\tcombined\n",
+        recent_outcomes_json='{"status":"success"}',
+    )
+    assert isinstance(out, Critique)
+    assert mock_client.call.call_args.kwargs["temperature"] == 0.3
+    # System prompt enforces critic posture: find problems, no fixes
+    sys_arg = mock_client.call.call_args.args[0]
+    sys_lower = sys_arg.lower()
+    assert "identify concrete problems" in sys_lower
+    assert "do not propose fixes" in sys_lower
+
+
+# ---------------------------------------------------------------------------
+# AuthorBAgent
+# ---------------------------------------------------------------------------
+
+AUTHOR_B_RESPONSE_SAMPLE = """# Rationale
+Raise PRODUCTNESS_CLS_WEIGHT from 0.02 to 0.05 to give the productness head a stronger gradient signal addressing the plateau in neg_acc identified by the critic.
+
+# Diff
+```
+diff --git a/student_finetune/train_v2.py b/student_finetune/train_v2.py
+--- a/student_finetune/train_v2.py
++++ b/student_finetune/train_v2.py
+@@ -120,7 +120,7 @@
+ USE_PRODUCTNESS_CLS = True
+-PRODUCTNESS_CLS_WEIGHT = 0.02
++PRODUCTNESS_CLS_WEIGHT = 0.05
+ PRODUCTNESS_HEAD_HIDDEN = 256
+```
+"""
+
+
+def test_parse_patch_proposal_extracts_rationale_and_diff():
+    p = _parse_patch_proposal(AUTHOR_B_RESPONSE_SAMPLE)
+    assert "0.05" in p.rationale
+    assert "diff --git" in p.diff
+    assert "PRODUCTNESS_CLS_WEIGHT = 0.05" in p.diff
+    assert p.raw == AUTHOR_B_RESPONSE_SAMPLE
+
+
+def test_parse_patch_proposal_no_patch_sentinel():
+    raw = (
+        "# Rationale\nNo changes proposed.\n\n"
+        "# Diff\nNO_PATCH"
+    )
+    p = _parse_patch_proposal(raw)
+    assert p.diff == ""
+    assert "No changes proposed" in p.rationale
+
+
+def test_parse_patch_proposal_no_patch_in_fence():
+    raw = (
+        "# Rationale\nNothing to do.\n\n"
+        "# Diff\n```\nNO_PATCH\n```"
+    )
+    p = _parse_patch_proposal(raw)
+    assert p.diff == ""
+
+
+def test_author_agent_system_prompt_forbids_v1_edits():
+    """The Author B system prompt must explicitly list every V1_FORBIDDEN_PATHS entry."""
+    from research_loop.agents.author import AUTHOR_B_SYSTEM_PROMPT
+    from research_loop.targets._base import V1_FORBIDDEN_PATHS
+
+    for path in V1_FORBIDDEN_PATHS:
+        assert path in AUTHOR_B_SYSTEM_PROMPT, f"V1 path {path} not enumerated in author prompt"
+
+
+def test_author_agent_calls_client_with_higher_temperature():
+    mock_client = MagicMock(spec=AgentClient)
+    mock_client.call.return_value = AUTHOR_B_RESPONSE_SAMPLE
+    agent = AuthorBAgent(mock_client)
+    out = agent.author(
+        trainer_source="x = 1\n",
+        trainer_path="student_finetune/train_v2.py",
+        critique_text="problem 1",
+    )
+    assert isinstance(out, PatchProposal)
+    assert mock_client.call.call_args.kwargs["temperature"] == 0.8
+
+
+# ---------------------------------------------------------------------------
+# SynthesizerAgent
+# ---------------------------------------------------------------------------
+
+SYNTH_RESPONSE_SAMPLE = """# Rationale
+Halved the proposed weight bump from 0.05 to 0.035, keeping the direction X identifies but committing less than its full step.
+
+# Diff
+```
+diff --git a/student_finetune/train_v2.py b/student_finetune/train_v2.py
+--- a/student_finetune/train_v2.py
++++ b/student_finetune/train_v2.py
+@@ -120,7 +120,7 @@
+ USE_PRODUCTNESS_CLS = True
+-PRODUCTNESS_CLS_WEIGHT = 0.02
++PRODUCTNESS_CLS_WEIGHT = 0.035
+ PRODUCTNESS_HEAD_HIDDEN = 256
+```
+"""
+
+
+def test_parse_synthesis_extracts_rationale_and_diff():
+    p = _parse_synthesis(SYNTH_RESPONSE_SAMPLE)
+    assert "halved" in p.rationale.lower() or "0.035" in p.rationale
+    assert "PRODUCTNESS_CLS_WEIGHT = 0.035" in p.diff
+
+
+def test_synthesizer_uses_anonymized_labels_in_user_message():
+    """Per autoreason paper §2: synthesizer sees X / Y, not A / B."""
+    mock_client = MagicMock(spec=AgentClient)
+    mock_client.call.return_value = SYNTH_RESPONSE_SAMPLE
+    agent = SynthesizerAgent(mock_client)
+    agent.synthesize(
+        patch_x="patch_x_text",
+        patch_y="patch_y_text",
+        trainer_path="student_finetune/train_v2.py",
+    )
+    user_message = mock_client.call.call_args.args[1]
+    assert "## Patch X" in user_message
+    assert "## Patch Y" in user_message
+    # Verifies anonymization: must NOT leak "A" / "B" / "AB" labels
+    assert "## Patch A" not in user_message
+    assert "## Patch B" not in user_message
+
+
+def test_synthesizer_does_not_see_metrics():
+    """Per project decision 2026-04-25: synthesizer sees only patches, no metric history."""
+    mock_client = MagicMock(spec=AgentClient)
+    mock_client.call.return_value = SYNTH_RESPONSE_SAMPLE
+    agent = SynthesizerAgent(mock_client)
+    agent.synthesize(
+        patch_x="patch_x", patch_y="patch_y",
+        trainer_path="student_finetune/train_v2.py",
+    )
+    user_message = mock_client.call.call_args.args[1]
+    # No metric keys should appear in the synthesizer's input
+    for forbidden_metric_term in ("combined", "recall_1", "productness_neg_acc", "results_v2"):
+        assert forbidden_metric_term not in user_message, \
+            f"Synthesizer leaked metric input: '{forbidden_metric_term}'"
+
+
+# ---------------------------------------------------------------------------
+# Fresh-agent invariant (cross-cutting)
+# ---------------------------------------------------------------------------
+
+def test_three_agents_make_three_independent_calls():
+    """All three roles share an AgentClient but never share message history.
+
+    Each .critique() / .author() / .synthesize() call invokes
+    AgentClient.call exactly once with a fresh user message.
+    """
+    mock_client = MagicMock(spec=AgentClient)
+    mock_client.call.side_effect = [
+        CRITIC_RESPONSE_SAMPLE,
+        AUTHOR_B_RESPONSE_SAMPLE,
+        SYNTH_RESPONSE_SAMPLE,
+    ]
+    critic = CriticAgent(mock_client)
+    author = AuthorBAgent(mock_client)
+    synth = SynthesizerAgent(mock_client)
+
+    critic.critique(
+        trainer_source="x = 1",
+        results_tsv_tail="",
+        recent_outcomes_json="",
+    )
+    author.author(
+        trainer_source="x = 1",
+        trainer_path="student_finetune/train_v2.py",
+        critique_text="...",
+    )
+    synth.synthesize(
+        patch_x="...", patch_y="...",
+        trainer_path="student_finetune/train_v2.py",
+    )
+
+    # Three distinct calls, each with its own system prompt
+    assert mock_client.call.call_count == 3
+    system_prompts = [c.args[0] for c in mock_client.call.call_args_list]
+    assert len(set(system_prompts)) == 3  # all three role prompts are distinct

--- a/research_loop/tests/test_autoreason_loop.py
+++ b/research_loop/tests/test_autoreason_loop.py
@@ -89,23 +89,27 @@ def fake_repo(monkeypatch, tmp_path: Path) -> Path:
 
 
 def _mock_agent_client_factory():
-    """Returns an AgentClient stub whose .call() returns role-appropriate canned text.
+    """Returns a per-role factory: cmd_autoreason calls factory("critic") etc.
 
-    The agents call `client.call(system, user)`. We dispatch on substring of
-    the system prompt so the same client serves all three roles.
+    Each role gets its own MagicMock so we can verify they're independent.
+    All three return canned role-appropriate text; the agents call
+    client.call(system, user) and we dispatch by system-prompt substring.
     """
-    client = MagicMock()
-    def call_fn(system, user, *, temperature=0.8, max_tokens=None):
-        s = system.lower()
-        if "identify concrete problems" in s:
-            return CRITIC_RAW
-        if "produce a unified diff that addresses" in s:
-            return AUTHOR_B_RAW
-        if "conservative synthesis" in s:
-            return SYNTH_RAW
-        raise AssertionError(f"Unrecognized system prompt: {system[:80]}")
-    client.call.side_effect = call_fn
-    return lambda: client
+    def make_client(role: str):
+        client = MagicMock()
+        def call_fn(system, user, *, temperature=0.8, max_tokens=None, timeout=None):
+            s = system.lower()
+            if "identify concrete problems" in s:
+                return CRITIC_RAW
+            if "produce a unified diff that addresses" in s:
+                return AUTHOR_B_RAW
+            if "conservative synthesis" in s:
+                return SYNTH_RAW
+            raise AssertionError(f"Unrecognized system prompt: {system[:80]}")
+        client.call.side_effect = call_fn
+        client.name = f"mock-{role}"
+        return client
+    return make_client
 
 
 def _patch_adapter_train(scripted_outcomes: list[dict]):
@@ -323,3 +327,39 @@ def test_autoreason_dry_run_skips_dirty_check(history_in_tmp, fake_repo, monkeyp
     )
     # At minimum, the critic should have run
     assert len(list(read_critiques(history_in_tmp))) == 1
+
+
+def test_autoreason_per_role_factory_called_with_each_role(history_in_tmp, fake_repo, monkeypatch):
+    """Per-role overrides: each role's factory call gets its own role string,
+    so callers can route Critic / Author / Synthesizer to different CLIs/models.
+    """
+    from research_loop.targets._base import TrainOutcome
+    from research_loop.targets.student_v2 import StudentV2Target
+
+    def fake_train(self, candidate, max_epochs=None, dry_run=False, log_path=None, max_seconds=None):
+        return TrainOutcome(
+            candidate_id=candidate.id, metrics={}, elapsed_seconds=0.0,
+            status="noop", log_path=Path("/dev/null"),
+            metrics_json_path=self.METRICS_JSON, return_code=0,
+        )
+    monkeypatch.setattr(StudentV2Target, "train", fake_train)
+    monkeypatch.setattr(StudentV2Target, "log_row", _stub_log_row)
+    monkeypatch.setattr(StudentV2Target, "METRICS_JSON", fake_repo / "metrics_final_v2.json")
+
+    # Per-role tracker — record which roles got which factory call
+    invocations: list[str] = []
+    def factory(role: str):
+        invocations.append(role)
+        # Reuse the canned-response client logic
+        return _mock_agent_client_factory()(role)
+
+    tournament.cmd_autoreason(
+        "student_v2",
+        max_passes=1, convergence=2,
+        max_seconds_per_candidate=None,
+        hypothesis_seed="test", dry_run=True,
+        agent_client_factory=factory,
+    )
+
+    # Factory must be called once per role with the role name
+    assert sorted(invocations) == ["author", "critic", "synthesizer"]

--- a/research_loop/tests/test_autoreason_loop.py
+++ b/research_loop/tests/test_autoreason_loop.py
@@ -329,6 +329,195 @@ def test_autoreason_dry_run_skips_dirty_check(history_in_tmp, fake_repo, monkeyp
     assert len(list(read_critiques(history_in_tmp))) == 1
 
 
+def test_autoreason_writes_summary_json_each_pass(history_in_tmp, fake_repo, monkeypatch, tmp_path):
+    """summary.json is written atomically at startup + after each pass + on exit.
+    External agents (Hermes, Slack bots) read this single file to answer
+    'how is training going?' without parsing logs.
+    """
+    metrics = {"combined": 0.86, "recall_1": 0.90, "mean_cosine": 0.81,
+               "productness_neg_acc": 0.85, "productness_pos_acc": 0.99}
+    fake_outcomes = [{"status": "success", "metrics": metrics}] * 6  # 2 passes × 3
+
+    from research_loop.targets.student_v2 import StudentV2Target
+    monkeypatch.setattr(StudentV2Target, "train", _patch_adapter_train(fake_outcomes))
+    monkeypatch.setattr(StudentV2Target, "log_row", _stub_log_row)
+    monkeypatch.setattr(StudentV2Target, "METRICS_JSON", fake_repo / "metrics_final_v2.json")
+
+    runs_dir = tmp_path / "runs"
+    monkeypatch.setattr(tournament, "RUNS_DIR", runs_dir)
+
+    rc = tournament.cmd_autoreason(
+        "student_v2",
+        max_passes=2, convergence=2,
+        max_seconds_per_candidate=None,
+        hypothesis_seed="test", dry_run=False,
+        agent_client_factory=_mock_agent_client_factory(),
+    )
+    assert rc == 0  # converged at k=2
+
+    # Exactly one run dir was created; summary.json present
+    run_dirs = [d for d in runs_dir.iterdir() if d.is_dir()]
+    assert len(run_dirs) == 1
+    summary_path = run_dirs[0] / "summary.json"
+    assert summary_path.exists()
+
+    # Final summary state should reflect convergence
+    import json
+    summary = json.loads(summary_path.read_text())
+    assert summary["status"] == "converged"
+    assert summary["target"] == "student_v2"
+    assert summary["current_pass"] == 2
+    assert summary["consecutive_a_wins"] >= 2
+    assert summary["last_decision"]["winner_kind"] == "A"
+    assert summary["best_so_far"]["combined"] == 0.86
+
+    # CURRENT pointer file exists
+    pointer = runs_dir / "student_v2_CURRENT.txt"
+    assert pointer.exists()
+    assert pointer.read_text() == run_dirs[0].name
+
+
+def test_autoreason_writes_narrative_log_to_run_dir(history_in_tmp, fake_repo, monkeypatch, tmp_path):
+    """run_dir/autoreason.log captures the narrative print() output. External
+    tooling (Hermes, Slack bots) can tail this single file from the path
+    summary.json points at."""
+    metrics = {"combined": 0.86, "recall_1": 0.90, "mean_cosine": 0.81,
+               "productness_neg_acc": 0.85, "productness_pos_acc": 0.99}
+    fake_outcomes = [{"status": "success", "metrics": metrics}] * 3
+
+    from research_loop.targets.student_v2 import StudentV2Target
+    monkeypatch.setattr(StudentV2Target, "train", _patch_adapter_train(fake_outcomes))
+    monkeypatch.setattr(StudentV2Target, "log_row", _stub_log_row)
+    monkeypatch.setattr(StudentV2Target, "METRICS_JSON", fake_repo / "metrics_final_v2.json")
+    monkeypatch.setattr(tournament, "RUNS_DIR", tmp_path / "runs")
+
+    tournament.cmd_autoreason(
+        "student_v2",
+        max_passes=1, convergence=2,
+        max_seconds_per_candidate=None,
+        hypothesis_seed="test", dry_run=False,
+        agent_client_factory=_mock_agent_client_factory(),
+    )
+
+    run_dirs = [d for d in (tmp_path / "runs").iterdir() if d.is_dir()]
+    log_path = run_dirs[0] / "autoreason.log"
+    assert log_path.exists()
+    content = log_path.read_text()
+    # Narrative milestones should be captured
+    assert "autoreason pass 1/1" in content
+    assert "critic:" in content
+    assert "running A" in content
+
+
+def test_autoreason_summary_status_max_passes_exhausted(history_in_tmp, fake_repo, monkeypatch, tmp_path):
+    """When max_passes hits without convergence, summary.json shows that status."""
+    a_metrics = {"combined": 0.80, "recall_1": 0.85, "mean_cosine": 0.75,
+                 "productness_neg_acc": 0.80, "productness_pos_acc": 0.99}
+    b_metrics = {"combined": 0.86, "recall_1": 0.90, "mean_cosine": 0.81,
+                 "productness_neg_acc": 0.85, "productness_pos_acc": 0.99}
+    fake_outcomes = []
+    for _ in range(3):
+        fake_outcomes.extend([
+            {"status": "success", "metrics": a_metrics},
+            {"status": "success", "metrics": b_metrics},
+            {"status": "success", "metrics": b_metrics},
+        ])
+
+    from research_loop.targets.student_v2 import StudentV2Target
+    monkeypatch.setattr(StudentV2Target, "train", _patch_adapter_train(fake_outcomes))
+    monkeypatch.setattr(StudentV2Target, "log_row", _stub_log_row)
+    monkeypatch.setattr(StudentV2Target, "METRICS_JSON", fake_repo / "metrics_final_v2.json")
+    monkeypatch.setattr(tournament, "RUNS_DIR", tmp_path / "runs")
+
+    rc = tournament.cmd_autoreason(
+        "student_v2",
+        max_passes=3, convergence=2,
+        max_seconds_per_candidate=None,
+        hypothesis_seed="test", dry_run=False,
+        agent_client_factory=_mock_agent_client_factory(),
+    )
+    assert rc != 0
+
+    runs = list((tmp_path / "runs").iterdir())
+    summary_path = next(d for d in runs if d.is_dir()) / "summary.json"
+    import json
+    summary = json.loads(summary_path.read_text())
+    assert summary["status"] == "max_passes_exhausted"
+
+
+def test_status_subcommand_renders_summary(history_in_tmp, fake_repo, monkeypatch, tmp_path, capsys):
+    """`tournament status` reads the latest run's summary.json and prints
+    a human/bot-readable block with all the headline fields."""
+    metrics = {"combined": 0.86, "recall_1": 0.90, "mean_cosine": 0.81,
+               "productness_neg_acc": 0.85, "productness_pos_acc": 0.99}
+    fake_outcomes = [{"status": "success", "metrics": metrics}] * 6
+
+    from research_loop.targets.student_v2 import StudentV2Target
+    monkeypatch.setattr(StudentV2Target, "train", _patch_adapter_train(fake_outcomes))
+    monkeypatch.setattr(StudentV2Target, "log_row", _stub_log_row)
+    monkeypatch.setattr(StudentV2Target, "METRICS_JSON", fake_repo / "metrics_final_v2.json")
+    monkeypatch.setattr(tournament, "RUNS_DIR", tmp_path / "runs")
+
+    tournament.cmd_autoreason(
+        "student_v2",
+        max_passes=2, convergence=2,
+        max_seconds_per_candidate=None,
+        hypothesis_seed="test", dry_run=False,
+        agent_client_factory=_mock_agent_client_factory(),
+    )
+    capsys.readouterr()  # flush autoreason's own output
+
+    rc = tournament.cmd_status(target="student_v2")
+    assert rc == 0
+    out = capsys.readouterr().out
+
+    # Headline fields all present
+    assert "autoreason status — student_v2" in out
+    assert "converged" in out
+    assert "Pass:" in out
+    assert "consecutive A wins:" in out
+    assert "Best so far:" in out
+    assert "combined=0.8600" in out
+    assert "Logs:" in out
+
+
+def test_status_subcommand_with_no_runs_returns_2(monkeypatch, tmp_path, capsys):
+    """`tournament status` without any runs surfaces a clear error + non-zero exit."""
+    monkeypatch.setattr(tournament, "RUNS_DIR", tmp_path / "runs")
+    rc = tournament.cmd_status(target="student_v2")
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "No" in err  # "No runs directory" or "No autoreason run found"
+
+
+def test_status_subcommand_resolves_explicit_run_id(history_in_tmp, fake_repo, monkeypatch, tmp_path, capsys):
+    """`tournament status --run RUN_ID` skips the CURRENT.txt pointer."""
+    metrics = {"combined": 0.86, "recall_1": 0.90, "mean_cosine": 0.81,
+               "productness_neg_acc": 0.85, "productness_pos_acc": 0.99}
+    fake_outcomes = [{"status": "success", "metrics": metrics}] * 6
+
+    from research_loop.targets.student_v2 import StudentV2Target
+    monkeypatch.setattr(StudentV2Target, "train", _patch_adapter_train(fake_outcomes))
+    monkeypatch.setattr(StudentV2Target, "log_row", _stub_log_row)
+    monkeypatch.setattr(StudentV2Target, "METRICS_JSON", fake_repo / "metrics_final_v2.json")
+    monkeypatch.setattr(tournament, "RUNS_DIR", tmp_path / "runs")
+
+    tournament.cmd_autoreason(
+        "student_v2", max_passes=2, convergence=2,
+        max_seconds_per_candidate=None,
+        hypothesis_seed="test", dry_run=False,
+        agent_client_factory=_mock_agent_client_factory(),
+    )
+    capsys.readouterr()
+
+    runs = [d for d in (tmp_path / "runs").iterdir() if d.is_dir()]
+    rid = runs[0].name
+    rc = tournament.cmd_status(run_id=rid)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert rid in out
+
+
 def test_autoreason_per_role_factory_called_with_each_role(history_in_tmp, fake_repo, monkeypatch):
     """Per-role overrides: each role's factory call gets its own role string,
     so callers can route Critic / Author / Synthesizer to different CLIs/models.

--- a/research_loop/tests/test_autoreason_loop.py
+++ b/research_loop/tests/test_autoreason_loop.py
@@ -1,0 +1,325 @@
+"""T6 verification: full autoreason convergence loop with mocked LLM + adapter.
+
+Tests the orchestrator at `research_loop.tournament.cmd_autoreason`. We:
+  - patch out the AgentClient to deterministic canned responses
+  - patch out the adapter's train() to return scripted outcomes (so we
+    control who wins each pass without real GPU)
+  - patch out the patch applicator's V1-safety check by writing a
+    benign no-op patch in the canned LLM responses
+  - assert the loop converges at k=2 consecutive A wins, hits max-passes
+    correctly, writes the expected record_type sequence to history.jsonl,
+    and respects the timeout veto.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from research_loop import tournament
+from research_loop.candidate import (
+    read_critiques,
+    read_decisions,
+    read_history,
+    read_outcomes,
+    read_patch_proposals,
+    read_syntheses,
+)
+
+
+# A diff that adds a comment to a file; applies and reverts cleanly.
+NOOP_DIFF = (
+    "diff --git a/student_finetune/train_v2.py b/student_finetune/train_v2.py\n"
+    "--- a/student_finetune/train_v2.py\n"
+    "+++ b/student_finetune/train_v2.py\n"
+    "@@ -1,2 +1,3 @@\n"
+    " USE_PRODUCTNESS_CLS = True\n"
+    "+# autoreason-test marker\n"
+    " PRODUCTNESS_CLS_WEIGHT = 0.02\n"
+)
+
+CRITIC_RAW = """# Summary
+Plateau on combined; productness neg_acc stuck at 0.76.
+
+# Problems
+- Productness CLS weight may be too low to drive gradient.
+"""
+
+AUTHOR_B_RAW = (
+    "# Rationale\nRaise productness weight to address plateau.\n\n"
+    "# Diff\n```\n" + NOOP_DIFF + "\n```\n"
+)
+
+SYNTH_RAW = (
+    "# Rationale\nHalved the proposed change.\n\n"
+    "# Diff\n```\n" + NOOP_DIFF + "\n```\n"
+)
+
+
+@pytest.fixture
+def history_in_tmp(monkeypatch, tmp_path: Path):
+    """Redirect HISTORY_PATH so tests don't pollute the real history.jsonl."""
+    p = tmp_path / "history.jsonl"
+    monkeypatch.setattr(tournament, "HISTORY_PATH", p)
+    return p
+
+
+@pytest.fixture
+def fake_repo(monkeypatch, tmp_path: Path) -> Path:
+    """Tiny git repo containing a stub student_finetune/train_v2.py the
+    NOOP_DIFF can apply to. Used as REPO_ROOT for the duration of the test."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@e.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True)
+    (repo / "student_finetune").mkdir()
+    (repo / "student_finetune" / "train_v2.py").write_text(
+        "USE_PRODUCTNESS_CLS = True\n"
+        "PRODUCTNESS_CLS_WEIGHT = 0.02\n"
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=repo, check=True)
+
+    monkeypatch.setattr(tournament, "REPO_ROOT", repo)
+    return repo
+
+
+def _mock_agent_client_factory():
+    """Returns an AgentClient stub whose .call() returns role-appropriate canned text.
+
+    The agents call `client.call(system, user)`. We dispatch on substring of
+    the system prompt so the same client serves all three roles.
+    """
+    client = MagicMock()
+    def call_fn(system, user, *, temperature=0.8, max_tokens=None):
+        s = system.lower()
+        if "identify concrete problems" in s:
+            return CRITIC_RAW
+        if "produce a unified diff that addresses" in s:
+            return AUTHOR_B_RAW
+        if "conservative synthesis" in s:
+            return SYNTH_RAW
+        raise AssertionError(f"Unrecognized system prompt: {system[:80]}")
+    client.call.side_effect = call_fn
+    return lambda: client
+
+
+def _patch_adapter_train(scripted_outcomes: list[dict]):
+    """Patch StudentV2Target.train() to return scripted TrainOutcomes in order.
+
+    Each entry should be a dict with keys for TrainOutcome (status, metrics,
+    elapsed_seconds, ...).
+    """
+    from research_loop.targets._base import TrainOutcome
+    iterator = iter(scripted_outcomes)
+
+    def fake_train(self, candidate, max_epochs=None, dry_run=False, log_path=None, max_seconds=None):
+        try:
+            payload = next(iterator)
+        except StopIteration:
+            payload = {"status": "success", "metrics": {"combined": 0.85, "recall_1": 0.9, "mean_cosine": 0.81, "productness_neg_acc": 0.85}}
+        return TrainOutcome(
+            candidate_id=candidate.id,
+            metrics=payload.get("metrics", {}),
+            elapsed_seconds=payload.get("elapsed_seconds", 1.0),
+            status=payload.get("status", "success"),
+            log_path=Path("/dev/null"),
+            metrics_json_path=self.METRICS_JSON,
+            return_code=payload.get("return_code", 0),
+        )
+    return fake_train
+
+
+def _stub_log_row(self, candidate, outcome):
+    """Skip TSV writes during tests — we only care about history.jsonl."""
+    return None
+
+
+def test_autoreason_converges_at_two_consecutive_a_wins(history_in_tmp, fake_repo, monkeypatch):
+    # Pass 1: A wins (B and AB are no better)
+    # Pass 2: A wins again → converges
+    a_wins_metrics = {"combined": 0.86, "recall_1": 0.90, "mean_cosine": 0.81, "productness_neg_acc": 0.85, "productness_pos_acc": 0.99}
+    b_loses_metrics = {"combined": 0.85, "recall_1": 0.89, "mean_cosine": 0.80, "productness_neg_acc": 0.84, "productness_pos_acc": 0.99}
+    scripted = [
+        a_wins_metrics, b_loses_metrics, b_loses_metrics,    # pass 1: A, B, AB
+        a_wins_metrics, b_loses_metrics, b_loses_metrics,    # pass 2: A, B, AB
+    ]
+    fake_outcomes = [{"status": "success", "metrics": m} for m in scripted]
+
+    from research_loop.targets.student_v2 import StudentV2Target
+    monkeypatch.setattr(StudentV2Target, "train", _patch_adapter_train(fake_outcomes))
+    monkeypatch.setattr(StudentV2Target, "log_row", _stub_log_row)
+    # Make adapter.METRICS_JSON point inside fake_repo so tests don't hit /data
+    monkeypatch.setattr(
+        StudentV2Target, "METRICS_JSON",
+        fake_repo / "metrics_final_v2.json",
+    )
+
+    rc = tournament.cmd_autoreason(
+        "student_v2",
+        max_passes=5, convergence=2,
+        max_seconds_per_candidate=None,
+        hypothesis_seed="test", dry_run=False,
+        agent_client_factory=_mock_agent_client_factory(),
+    )
+    assert rc == 0  # converged
+
+    decisions = list(read_decisions(history_in_tmp))
+    assert len(decisions) == 2
+    assert all(d.winner_kind == "A" for d in decisions)
+
+
+def test_autoreason_records_full_audit_trail(history_in_tmp, fake_repo, monkeypatch):
+    """Every pass writes critique + patch_proposal + synthesis + 3×candidate +
+    3×outcome + 1×decision = 10 records. After 1 pass we expect that count."""
+    metrics = {"combined": 0.86, "recall_1": 0.90, "mean_cosine": 0.81, "productness_neg_acc": 0.85, "productness_pos_acc": 0.99}
+    fake_outcomes = [{"status": "success", "metrics": metrics}] * 3
+
+    from research_loop.targets.student_v2 import StudentV2Target
+    monkeypatch.setattr(StudentV2Target, "train", _patch_adapter_train(fake_outcomes))
+    monkeypatch.setattr(StudentV2Target, "log_row", _stub_log_row)
+    monkeypatch.setattr(
+        StudentV2Target, "METRICS_JSON",
+        fake_repo / "metrics_final_v2.json",
+    )
+
+    # max_passes=1, convergence=2 → won't converge but exits cleanly after 1
+    rc = tournament.cmd_autoreason(
+        "student_v2",
+        max_passes=1, convergence=2,
+        max_seconds_per_candidate=None,
+        hypothesis_seed="test", dry_run=False,
+        agent_client_factory=_mock_agent_client_factory(),
+    )
+    assert rc == 1  # max_passes exhausted
+
+    # All record types present
+    assert len(list(read_critiques(history_in_tmp))) == 1
+    assert len(list(read_patch_proposals(history_in_tmp))) == 1
+    assert len(list(read_syntheses(history_in_tmp))) == 1
+    candidates = list(read_history(history_in_tmp))
+    kinds = sorted(c.kind for c in candidates)
+    assert kinds == ["A", "AB", "B"]
+    outcomes = list(read_outcomes(history_in_tmp))
+    assert len(outcomes) == 3
+    assert len(list(read_decisions(history_in_tmp))) == 1
+
+
+def test_autoreason_max_passes_returns_nonzero(history_in_tmp, fake_repo, monkeypatch):
+    """When max_passes is hit without convergence, exit code is non-zero."""
+    # B and AB always score better than A → A never wins
+    a_metrics = {"combined": 0.80, "recall_1": 0.85, "mean_cosine": 0.75, "productness_neg_acc": 0.80, "productness_pos_acc": 0.99}
+    b_metrics = {"combined": 0.86, "recall_1": 0.90, "mean_cosine": 0.81, "productness_neg_acc": 0.85, "productness_pos_acc": 0.99}
+    fake_outcomes = []
+    for _ in range(3):
+        fake_outcomes.extend([
+            {"status": "success", "metrics": a_metrics},  # A
+            {"status": "success", "metrics": b_metrics},  # B wins
+            {"status": "success", "metrics": b_metrics},  # AB
+        ])
+
+    from research_loop.targets.student_v2 import StudentV2Target
+    monkeypatch.setattr(StudentV2Target, "train", _patch_adapter_train(fake_outcomes))
+    monkeypatch.setattr(StudentV2Target, "log_row", _stub_log_row)
+    monkeypatch.setattr(
+        StudentV2Target, "METRICS_JSON",
+        fake_repo / "metrics_final_v2.json",
+    )
+
+    rc = tournament.cmd_autoreason(
+        "student_v2",
+        max_passes=3, convergence=2,
+        max_seconds_per_candidate=None,
+        hypothesis_seed="test", dry_run=False,
+        agent_client_factory=_mock_agent_client_factory(),
+    )
+    assert rc != 0  # never converged
+
+
+def test_autoreason_dry_run_records_noop_outcomes(history_in_tmp, fake_repo, monkeypatch):
+    """Dry-run skips real subprocess training but still drives the LLM loop."""
+    # Have train() return noop outcomes when dry_run=True
+    from research_loop.targets._base import TrainOutcome
+    from research_loop.targets.student_v2 import StudentV2Target
+
+    def fake_train(self, candidate, max_epochs=None, dry_run=False, log_path=None, max_seconds=None):
+        assert dry_run, "Expected dry_run=True"
+        return TrainOutcome(
+            candidate_id=candidate.id, metrics={}, elapsed_seconds=0.0,
+            status="noop", log_path=Path("/dev/null"),
+            metrics_json_path=self.METRICS_JSON, return_code=0,
+        )
+
+    monkeypatch.setattr(StudentV2Target, "train", fake_train)
+    monkeypatch.setattr(StudentV2Target, "log_row", _stub_log_row)
+    monkeypatch.setattr(
+        StudentV2Target, "METRICS_JSON",
+        fake_repo / "metrics_final_v2.json",
+    )
+
+    # Dry-run cmd_autoreason
+    # cmd_promote will fail because all outcomes are status="noop"
+    # so we expect a non-zero exit but with audit records written
+    rc = tournament.cmd_autoreason(
+        "student_v2",
+        max_passes=1, convergence=2,
+        max_seconds_per_candidate=None,
+        hypothesis_seed="test", dry_run=True,
+        agent_client_factory=_mock_agent_client_factory(),
+    )
+    # rc may be != 0 because no successful outcome → no decision possible
+    # but we still want audit records to exist
+    assert len(list(read_critiques(history_in_tmp))) == 1
+
+
+def test_autoreason_refuses_dirty_working_tree(history_in_tmp, fake_repo, monkeypatch):
+    # Make the tree dirty
+    (fake_repo / "stray.txt").write_text("dirty")
+
+    rc = tournament.cmd_autoreason(
+        "student_v2",
+        max_passes=1, convergence=2,
+        max_seconds_per_candidate=None,
+        hypothesis_seed="test", dry_run=False,
+        agent_client_factory=_mock_agent_client_factory(),
+    )
+    assert rc == 2  # refused
+    # Nothing should have been written
+    assert not history_in_tmp.exists() or history_in_tmp.read_text() == ""
+
+
+def test_autoreason_dry_run_skips_dirty_check(history_in_tmp, fake_repo, monkeypatch):
+    """Dry-run should not require a clean tree (it doesn't apply patches anyway)."""
+    (fake_repo / "stray.txt").write_text("dirty")
+
+    from research_loop.targets._base import TrainOutcome
+    from research_loop.targets.student_v2 import StudentV2Target
+
+    def fake_train(self, candidate, max_epochs=None, dry_run=False, log_path=None, max_seconds=None):
+        return TrainOutcome(
+            candidate_id=candidate.id, metrics={}, elapsed_seconds=0.0,
+            status="noop", log_path=Path("/dev/null"),
+            metrics_json_path=self.METRICS_JSON, return_code=0,
+        )
+
+    monkeypatch.setattr(StudentV2Target, "train", fake_train)
+    monkeypatch.setattr(StudentV2Target, "log_row", _stub_log_row)
+    monkeypatch.setattr(
+        StudentV2Target, "METRICS_JSON",
+        fake_repo / "metrics_final_v2.json",
+    )
+
+    # Should run without complaining about dirty tree
+    tournament.cmd_autoreason(
+        "student_v2",
+        max_passes=1, convergence=2,
+        max_seconds_per_candidate=None,
+        hypothesis_seed="test", dry_run=True,
+        agent_client_factory=_mock_agent_client_factory(),
+    )
+    # At minimum, the critic should have run
+    assert len(list(read_critiques(history_in_tmp))) == 1

--- a/research_loop/tests/test_budget.py
+++ b/research_loop/tests/test_budget.py
@@ -1,0 +1,150 @@
+"""T2 verification: per-trial time budget on adapter.train().
+
+Uses a stub trainer (a tiny shell script written into a tmp dir) instead of
+the real GPU pipeline. Asserts:
+  - subprocess killed within 60s of max_seconds expiry (we use 1-3s in tests)
+  - status == "timeout"
+  - partial metrics from metrics_progress_v2.json are recovered when present
+  - promote.decide() rejects timeout candidates regardless of metric values
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from research_loop.candidate import Candidate
+from research_loop.promote import CandidateResult, decide
+from research_loop.targets._base import TargetAdapter, TrainOutcome
+
+
+@pytest.fixture
+def stub_trainer_factory(tmp_path: Path):
+    """Build a stub trainer dir that simulates a slow Python trainer.
+
+    The trainer writes metrics_progress_v2.json after a short delay, then
+    sleeps for `sleep_seconds` (so the adapter's max_seconds budget kicks in).
+    Returns the adapter pointed at this stub.
+    """
+
+    def _make(sleep_seconds: float = 5.0, write_progress: bool = True):
+        trainer = tmp_path / "fake_train.py"
+        trainer.write_text(
+            "import json, sys, time\n"
+            "from pathlib import Path\n"
+            "out = Path(__file__).parent / 'metrics_progress_v2.json'\n"
+            f"if {write_progress}:\n"
+            "    payload = {\n"
+            "        'status': 'in_progress', 'is_partial': True,\n"
+            "        'epochs_completed': 1, 'max_epochs': 30,\n"
+            "        'combined_metric': 0.42, 'best_combined': 0.42,\n"
+            "        'recall_at_1': 0.5, 'recall_at_5': 0.6,\n"
+            "        'mean_cosine': 0.34, 'distill_loss': 1.2,\n"
+            "    }\n"
+            "    out.write_text(json.dumps(payload))\n"
+            "time.sleep(0.2)  # let adapter see the progress file\n"
+            f"time.sleep({sleep_seconds})\n"
+        )
+
+        class StubAdapter(TargetAdapter):
+            name = "stub_v2"
+            REPO_DIR = tmp_path
+            RESULTS_TSV = tmp_path / "results_v2.tsv"
+            METRICS_JSON = tmp_path / "metrics_final_v2.json"
+            TRAIN_CMD = ["python", str(trainer)]
+            DEFAULT_EPOCHS = 1
+            SIGTERM_GRACE_SECONDS = 1.0  # speed up tests
+
+        return StubAdapter()
+
+    return _make
+
+
+def _candidate():
+    return Candidate(
+        kind="A", target="student_v2", round_id="r-budget-test",
+        hypothesis="incumbent baseline",
+        expected_metric="combined Δ +0.000", changed_files=[], risks=[],
+        rollback="N/A", patch="",
+    )
+
+
+def test_budget_kills_overrunning_subprocess(stub_trainer_factory):
+    """3s budget on a 30s-sleep stub → killed within ~5s, status='timeout'."""
+    adapter = stub_trainer_factory(sleep_seconds=30, write_progress=False)
+    candidate = _candidate()
+    t0 = time.time()
+    outcome = adapter.train(candidate, max_epochs=1, max_seconds=3.0)
+    elapsed = time.time() - t0
+    assert outcome.status == "timeout"
+    # Killed shortly after budget + 1s grace + small slack
+    assert elapsed < 10.0, f"budget overrun: elapsed={elapsed:.1f}s"
+
+
+def test_budget_recovers_partial_metrics_from_progress_json(stub_trainer_factory):
+    """Stub writes metrics_progress; adapter parses on timeout."""
+    adapter = stub_trainer_factory(sleep_seconds=30, write_progress=True)
+    outcome = adapter.train(_candidate(), max_epochs=1, max_seconds=3.0)
+    assert outcome.status == "timeout"
+    # Progress was written before the sleep, so adapter should have it
+    assert outcome.metrics
+    assert outcome.metrics.get("combined") == 0.42
+    assert outcome.metrics.get("recall_1") == 0.5
+
+
+def test_budget_no_progress_file_yields_empty_metrics(stub_trainer_factory):
+    """Timeout before any eval → no progress file → empty metrics dict."""
+    adapter = stub_trainer_factory(sleep_seconds=30, write_progress=False)
+    outcome = adapter.train(_candidate(), max_epochs=1, max_seconds=2.0)
+    assert outcome.status == "timeout"
+    assert outcome.metrics == {}
+
+
+def test_no_budget_means_no_timeout(stub_trainer_factory):
+    """When max_seconds=None the adapter waits indefinitely (current behavior preserved)."""
+    # Use sleep=0.5 so the test stays fast
+    adapter = stub_trainer_factory(sleep_seconds=0.5, write_progress=False)
+    outcome = adapter.train(_candidate(), max_epochs=1, max_seconds=None)
+    # Trainer didn't write metrics_final_v2.json so this counts as "failed"
+    # (the trainer-success path is exercised by test_tournament_flow.py).
+    assert outcome.status != "timeout"
+
+
+def test_promote_decide_rejects_timeout_outcome():
+    """A timeout candidate cannot win, regardless of how good the partial metrics look."""
+    a = CandidateResult(
+        candidate_id="a", kind="A",
+        combined=0.86, recall_1=0.90, mean_cosine=0.81,
+        productness_pos_acc=0.99, productness_neg_acc=0.85,
+        status="success",
+    )
+    b_timeout = CandidateResult(
+        candidate_id="b", kind="B",
+        # Partial metrics happen to look better than A — must NOT win
+        combined=0.95, recall_1=0.95, mean_cosine=0.90,
+        productness_pos_acc=0.99, productness_neg_acc=0.90,
+        status="timeout",  # ← the veto
+    )
+    decision = decide([a, b_timeout])
+    assert decision.winner_kind == "A"
+    assert decision.promote is False
+
+
+def test_promote_decide_rejects_failed_outcome():
+    """Same veto applies to status='failed'."""
+    a = CandidateResult(
+        candidate_id="a", kind="A",
+        combined=0.86, recall_1=0.90, mean_cosine=0.81,
+        status="success",
+    )
+    b_failed = CandidateResult(
+        candidate_id="b", kind="B",
+        combined=0.99, recall_1=0.99, mean_cosine=0.99,
+        status="failed: import error",
+    )
+    decision = decide([a, b_failed])
+    assert decision.winner_kind == "A"

--- a/research_loop/tests/test_patch_applicator.py
+++ b/research_loop/tests/test_patch_applicator.py
@@ -1,0 +1,190 @@
+"""T3 verification: research_loop.patch.apply_patch().
+
+Spins up tmp git repos as fixtures (no monkeypatch — real git invocations).
+Tests the contract: apply mutates, revert restores; V1 paths refused before
+any mutation; malformed diffs raise; revert runs even when the body raises.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from research_loop.patch import apply_patch, diff_touches_v1
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """A clean tmp git repo with one tracked file resembling student_finetune/train_v2.py."""
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path, check=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
+
+    (tmp_path / "student_finetune").mkdir()
+    target = tmp_path / "student_finetune" / "train_v2.py"
+    target.write_text(
+        "USE_PRODUCTNESS_CLS = True\n"
+        "PRODUCTNESS_CLS_WEIGHT = 0.02\n"
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-qm", "init"],
+        cwd=tmp_path, check=True,
+    )
+    return tmp_path
+
+
+def _make_diff(target_rel: str, old: str, new: str) -> str:
+    """Build a minimal unified diff (one-line replace, sufficient for apply)."""
+    return (
+        f"diff --git a/{target_rel} b/{target_rel}\n"
+        f"--- a/{target_rel}\n"
+        f"+++ b/{target_rel}\n"
+        f"@@ -1,2 +1,2 @@\n"
+        f"-{old}\n"
+        f"+{new}\n"
+        f" PRODUCTNESS_CLS_WEIGHT = 0.02\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# diff_touches_v1
+# ---------------------------------------------------------------------------
+
+def test_diff_touches_v1_detects_train_py():
+    diff = "--- a/student_finetune/train.py\n+++ b/student_finetune/train.py\n"
+    assert "student_finetune/train.py" in diff_touches_v1(diff)
+
+
+def test_diff_touches_v1_passes_v2_files():
+    diff = "--- a/student_finetune/train_v2.py\n+++ b/student_finetune/train_v2.py\n"
+    assert diff_touches_v1(diff) == []
+
+
+def test_diff_touches_v1_detects_results_tsv():
+    diff = "--- a/student_finetune/results.tsv\n+++ b/student_finetune/results.tsv\n"
+    assert "student_finetune/results.tsv" in diff_touches_v1(diff)
+
+
+def test_diff_touches_v1_detects_prepare_py():
+    diff = (
+        "diff --git a/student_finetune/prepare.py b/student_finetune/prepare.py\n"
+        "--- a/student_finetune/prepare.py\n"
+        "+++ b/student_finetune/prepare.py\n"
+    )
+    assert "student_finetune/prepare.py" in diff_touches_v1(diff)
+
+
+# ---------------------------------------------------------------------------
+# apply_patch contract
+# ---------------------------------------------------------------------------
+
+def test_apply_then_revert_restores_tree(git_repo: Path):
+    target = git_repo / "student_finetune" / "train_v2.py"
+    original = target.read_text()
+    diff = _make_diff(
+        "student_finetune/train_v2.py",
+        "USE_PRODUCTNESS_CLS = True",
+        "USE_PRODUCTNESS_CLS = False",
+    )
+    with apply_patch(diff, repo=git_repo):
+        assert "USE_PRODUCTNESS_CLS = False" in target.read_text()
+    # After context exit: original restored
+    assert target.read_text() == original
+
+
+def test_revert_runs_even_when_body_raises(git_repo: Path):
+    target = git_repo / "student_finetune" / "train_v2.py"
+    original = target.read_text()
+    diff = _make_diff(
+        "student_finetune/train_v2.py",
+        "USE_PRODUCTNESS_CLS = True",
+        "USE_PRODUCTNESS_CLS = False",
+    )
+    with pytest.raises(RuntimeError, match="boom"):
+        with apply_patch(diff, repo=git_repo):
+            assert "USE_PRODUCTNESS_CLS = False" in target.read_text()
+            raise RuntimeError("boom")
+    # Body raised, but revert still ran:
+    assert target.read_text() == original
+
+
+def test_apply_refuses_v1_path_before_mutation(git_repo: Path):
+    # Add a V1 file so we can verify it stays untouched
+    v1 = git_repo / "student_finetune" / "train.py"
+    v1.write_text("# V1 sacred\n")
+    subprocess.run(["git", "add", "."], cwd=git_repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "v1"], cwd=git_repo, check=True)
+
+    diff = _make_diff(
+        "student_finetune/train.py",
+        "# V1 sacred",
+        "# V1 violated",
+    )
+    original = v1.read_text()
+    with pytest.raises(ValueError, match="V1_FORBIDDEN_PATHS"):
+        with apply_patch(diff, repo=git_repo):
+            pass
+    assert v1.read_text() == original  # not touched
+
+
+def test_malformed_diff_raises_called_process_error(git_repo: Path):
+    bad_diff = "this is not a diff\n"
+    # Empty by parser standards (no +++/--- headers) → counted as no-op, yields cleanly.
+    # Provide something that *looks* like a diff but won't apply.
+    bad_diff = (
+        "--- a/student_finetune/train_v2.py\n"
+        "+++ b/student_finetune/train_v2.py\n"
+        "@@ -99,2 +99,2 @@\n"  # nonexistent line range
+        "-IMPOSSIBLE_LINE\n"
+        "+IMPOSSIBLE_REPLACE\n"
+    )
+    with pytest.raises(subprocess.CalledProcessError):
+        with apply_patch(bad_diff, repo=git_repo):
+            pass
+
+
+def test_empty_diff_is_noop(git_repo: Path):
+    """kind='A' baseline has empty patch — must yield without mutation."""
+    target = git_repo / "student_finetune" / "train_v2.py"
+    original = target.read_text()
+    with apply_patch("", repo=git_repo):
+        assert target.read_text() == original
+
+
+def test_dirty_tree_refuses_apply(git_repo: Path):
+    target = git_repo / "student_finetune" / "train_v2.py"
+    target.write_text(target.read_text() + "\n# dirty\n")  # uncommitted change
+
+    diff = _make_diff(
+        "student_finetune/train_v2.py",
+        "USE_PRODUCTNESS_CLS = True",
+        "USE_PRODUCTNESS_CLS = False",
+    )
+    with pytest.raises(RuntimeError, match="Working tree is dirty"):
+        with apply_patch(diff, repo=git_repo):
+            pass
+
+
+def test_dirty_tree_check_can_be_overridden(git_repo: Path):
+    """Tests that exercise a temp repo built fresh per-test should be allowed
+    to skip the cleanliness check via require_clean_tree=False."""
+    diff = _make_diff(
+        "student_finetune/train_v2.py",
+        "USE_PRODUCTNESS_CLS = True",
+        "USE_PRODUCTNESS_CLS = False",
+    )
+    # Add a stray untracked file to make the tree dirty
+    (git_repo / "stray.txt").write_text("scratch")
+    with apply_patch(diff, repo=git_repo, require_clean_tree=False):
+        assert (git_repo / "student_finetune" / "train_v2.py").read_text().count("False") == 1

--- a/research_loop/tools/autoreason_smoke.py
+++ b/research_loop/tools/autoreason_smoke.py
@@ -1,28 +1,35 @@
 """Manual real-LLM smoke for the autoreason loop (T8).
 
-Runs ONE autoreason pass against the real Anthropic API in dry-run mode
-(no GPU subprocess). Confirms:
+Runs ONE autoreason pass against a real local LLM CLI (hermes, claude, or
+codex) in dry-run mode (no GPU subprocess). Confirms:
 
-  1. AgentClient can authenticate (ANTHROPIC_API_KEY is reachable)
+  1. The chosen CLI is callable and returns text
   2. CriticAgent produces a parseable Critique with at least a summary
   3. AuthorBAgent produces a unified diff that `git apply --check` accepts
      (or NO_PATCH if the critic found nothing actionable)
   4. SynthesizerAgent produces a unified diff that `git apply --check`
      accepts (or NO_PATCH)
-  5. Working tree is restored after each candidate (via apply_patch's
-     try/finally — verified by git status check at the end)
+  5. Working tree is unchanged at the end (smoke only `--check`s, never applies)
 
-Cost: ~3 LLM calls × Sonnet 4.6 ≈ $0.05 per smoke run.
+Cost: ~3 CLI invocations. Per-call latency depends on which CLI / model is
+selected.
 
 Usage:
-  ANTHROPIC_API_KEY=sk-... .venv/bin/python -m research_loop.tools.autoreason_smoke
+  # hermes (default — uses repo's existing autoresearch CLI)
+  .venv/bin/python -m research_loop.tools.autoreason_smoke
+
+  # claude with explicit model
+  .venv/bin/python -m research_loop.tools.autoreason_smoke --llm-cli claude --llm-model claude-sonnet-4-6
+
+  # codex
+  .venv/bin/python -m research_loop.tools.autoreason_smoke --llm-cli codex
 
 Requires a clean working tree. Safe to re-run.
 """
 
 from __future__ import annotations
 
-import json
+import argparse
 import subprocess
 import sys
 from pathlib import Path
@@ -31,18 +38,20 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(description="Real-LLM smoke for the autoreason loop")
+    parser.add_argument("--llm-cli", choices=["hermes", "claude", "codex"], default=None,
+                        help="local LLM CLI (default: AUTORESEARCH_LLM_CLI env or 'hermes')")
+    parser.add_argument("--llm-model", default=None,
+                        help="model name forwarded to the selected CLI")
+    parser.add_argument("--llm-provider", default="auto",
+                        help="hermes provider routing (ignored by claude/codex)")
+    args = parser.parse_args()
+
     print(f"=== autoreason real-LLM smoke ===")
     print(f"Repo: {REPO_ROOT}")
     sys.path.insert(0, str(REPO_ROOT))
 
-    # 1. Resolve API key (will raise if missing)
-    from research_loop.agents.client import AgentClient, resolve_api_key
-    try:
-        key = resolve_api_key()
-        print(f"API key found: {key[:10]}...{key[-4:]}")
-    except RuntimeError as e:
-        print(f"FAIL: {e}", file=sys.stderr)
-        return 1
+    from research_loop.agents.client import make_llm_client
 
     # 2. Working tree must be clean — autoreason refuses dirty trees
     res = subprocess.run(
@@ -54,8 +63,9 @@ def main() -> int:
         return 1
     print("Working tree clean.")
 
-    # 3. Build agents
-    client = AgentClient()
+    # 3. Build agents — pick the CLI requested by the operator
+    client = make_llm_client(args.llm_cli, model=args.llm_model, provider=args.llm_provider)
+    print(f"LLM client: {client.name}" + (f" model={args.llm_model}" if args.llm_model else ""))
     from research_loop.agents.author import AuthorBAgent
     from research_loop.agents.critic import CriticAgent
     from research_loop.agents.synthesizer import SynthesizerAgent

--- a/research_loop/tools/autoreason_smoke.py
+++ b/research_loop/tools/autoreason_smoke.py
@@ -1,0 +1,164 @@
+"""Manual real-LLM smoke for the autoreason loop (T8).
+
+Runs ONE autoreason pass against the real Anthropic API in dry-run mode
+(no GPU subprocess). Confirms:
+
+  1. AgentClient can authenticate (ANTHROPIC_API_KEY is reachable)
+  2. CriticAgent produces a parseable Critique with at least a summary
+  3. AuthorBAgent produces a unified diff that `git apply --check` accepts
+     (or NO_PATCH if the critic found nothing actionable)
+  4. SynthesizerAgent produces a unified diff that `git apply --check`
+     accepts (or NO_PATCH)
+  5. Working tree is restored after each candidate (via apply_patch's
+     try/finally — verified by git status check at the end)
+
+Cost: ~3 LLM calls × Sonnet 4.6 ≈ $0.05 per smoke run.
+
+Usage:
+  ANTHROPIC_API_KEY=sk-... .venv/bin/python -m research_loop.tools.autoreason_smoke
+
+Requires a clean working tree. Safe to re-run.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    print(f"=== autoreason real-LLM smoke ===")
+    print(f"Repo: {REPO_ROOT}")
+    sys.path.insert(0, str(REPO_ROOT))
+
+    # 1. Resolve API key (will raise if missing)
+    from research_loop.agents.client import AgentClient, resolve_api_key
+    try:
+        key = resolve_api_key()
+        print(f"API key found: {key[:10]}...{key[-4:]}")
+    except RuntimeError as e:
+        print(f"FAIL: {e}", file=sys.stderr)
+        return 1
+
+    # 2. Working tree must be clean — autoreason refuses dirty trees
+    res = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+    )
+    if res.stdout.strip():
+        print(f"FAIL: working tree dirty:\n{res.stdout}", file=sys.stderr)
+        return 1
+    print("Working tree clean.")
+
+    # 3. Build agents
+    client = AgentClient()
+    from research_loop.agents.author import AuthorBAgent
+    from research_loop.agents.critic import CriticAgent
+    from research_loop.agents.synthesizer import SynthesizerAgent
+    critic = CriticAgent(client)
+    author = AuthorBAgent(client)
+    synth = SynthesizerAgent(client)
+
+    # 4. Read inputs (current student_v2 trainer + recent history if any)
+    trainer_path = "student_finetune/train_v2.py"
+    trainer_src = (REPO_ROOT / trainer_path).read_text()
+    results_tsv = REPO_ROOT / "student_finetune" / "results_v2.tsv"
+    results_tail = (
+        "\n".join(results_tsv.read_text().splitlines()[-30:])
+        if results_tsv.exists() else ""
+    )
+    history = REPO_ROOT / "research_loop" / "history.jsonl"
+    recent_outcomes = ""
+    if history.exists():
+        outcomes = [
+            line for line in history.read_text().splitlines()
+            if '"record_type": "outcome"' in line
+        ][-10:]
+        recent_outcomes = "\n".join(outcomes)
+
+    # 5. Critic
+    print("\n[1/3] Critic...")
+    critique = critic.critique(
+        trainer_source=trainer_src,
+        results_tsv_tail=results_tail,
+        recent_outcomes_json=recent_outcomes,
+    )
+    print(f"  summary ({len(critique.summary)} chars): {critique.summary[:200]}")
+    print(f"  problems: {len(critique.problems)}")
+    for p in critique.problems[:3]:
+        print(f"    - {p[:120]}")
+    assert critique.summary, "Critic returned empty summary"
+
+    # 6. Author B
+    print("\n[2/3] Author B...")
+    proposal = author.author(
+        trainer_source=trainer_src,
+        trainer_path=trainer_path,
+        critique_text=critique.raw,
+    )
+    print(f"  rationale ({len(proposal.rationale)} chars): {proposal.rationale[:200]}")
+    print(f"  diff length: {len(proposal.diff)} chars")
+    if proposal.diff:
+        # Verify it would apply
+        check = subprocess.run(
+            ["git", "apply", "--check"],
+            cwd=REPO_ROOT, input=proposal.diff,
+            capture_output=True, text=True, check=False,
+        )
+        if check.returncode != 0:
+            print(f"  FAIL: Author B's diff does not apply:\n{check.stderr}", file=sys.stderr)
+            print(f"\nDiff content:\n{proposal.diff}", file=sys.stderr)
+            return 1
+        print("  diff applies cleanly via `git apply --check`")
+    else:
+        print("  (NO_PATCH — critic found no actionable problems)")
+
+    # 7. Synthesizer
+    print("\n[3/3] Synthesizer...")
+    synthesis = synth.synthesize(
+        patch_x="",  # A is do-nothing
+        patch_y=proposal.diff,
+        trainer_path=trainer_path,
+    )
+    print(f"  rationale ({len(synthesis.rationale)} chars): {synthesis.rationale[:200]}")
+    print(f"  diff length: {len(synthesis.diff)} chars")
+    if synthesis.diff:
+        check = subprocess.run(
+            ["git", "apply", "--check"],
+            cwd=REPO_ROOT, input=synthesis.diff,
+            capture_output=True, text=True, check=False,
+        )
+        if check.returncode != 0:
+            print(f"  FAIL: Synthesizer diff does not apply:\n{check.stderr}", file=sys.stderr)
+            print(f"\nDiff content:\n{synthesis.diff}", file=sys.stderr)
+            return 1
+        print("  diff applies cleanly via `git apply --check`")
+    else:
+        print("  (NO_PATCH — synthesis is empty)")
+
+    # 8. Working tree should still be clean (we only ran --check, never applied)
+    res = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+    )
+    assert not res.stdout.strip(), f"Working tree dirty after smoke: {res.stdout}"
+    print("\nWorking tree still clean after smoke.")
+
+    # 9. Print summary for HANDOFF.md evidence
+    print("\n" + "=" * 60)
+    print("SMOKE PASSED")
+    print(f"  Critic: {len(critique.problems)} problems found")
+    print(f"  Author B: {'NO_PATCH' if not proposal.diff else f'{len(proposal.diff)} char diff'}")
+    print(f"  Synthesizer: {'NO_PATCH' if not synthesis.diff else f'{len(synthesis.diff)} char diff'}")
+    print(f"  Both diffs (if non-empty) pass `git apply --check`")
+    print(f"  Working tree clean throughout")
+    print("=" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research_loop/tournament.py
+++ b/research_loop/tournament.py
@@ -349,10 +349,20 @@ def cmd_autoreason(
     max_seconds_per_candidate: float | None,
     hypothesis_seed: str,
     dry_run: bool,
+    # Global defaults (inherited by all three roles unless overridden below)
     llm_cli: str | None = None,
     llm_model: str | None = None,
     llm_provider: str = "auto",
-    agent_client_factory=None,
+    # Per-role overrides — None means inherit the global default. Per
+    # autoreason paper §7.3, mixing models across roles is well-supported
+    # (e.g. cheap author + strong judge); we expose the same flexibility.
+    critic_cli: str | None = None,
+    critic_model: str | None = None,
+    author_cli: str | None = None,
+    author_model: str | None = None,
+    synthesizer_cli: str | None = None,
+    synthesizer_model: str | None = None,
+    agent_client_factory=None,  # test injection; takes (role_name) → LLMClient
 ) -> int:
     """Fully autonomous autoreason loop.
 
@@ -362,11 +372,12 @@ def cmd_autoreason(
     A wins or after `max_passes` total passes.
 
     LLM access is via subprocess to a local CLI (hermes / claude / codex).
-    `llm_cli` defaults to AUTORESEARCH_LLM_CLI env or "hermes". `llm_model`
-    is passed through to whichever CLI is selected.
+    Each role can use a different CLI and/or model — autoreason paper §7.3
+    showed mixed-model setups (cheap author + strong judge) are first-class.
+    Per-role values default to the global llm_cli / llm_model / llm_provider.
 
     `agent_client_factory` is injected for testing — production callers pass
-    None and we construct a real CLI-backed client.
+    None and we construct a real CLI-backed client per role.
     """
     if target not in TARGETS:
         print(f"Unknown target: {target}", file=sys.stderr)
@@ -380,22 +391,36 @@ def cmd_autoreason(
         )
         return 2
 
+    # Resolve per-role config (fall back to globals)
+    role_config = {
+        "critic":       (critic_cli       or llm_cli, critic_model       or llm_model),
+        "author":       (author_cli       or llm_cli, author_model       or llm_model),
+        "synthesizer":  (synthesizer_cli  or llm_cli, synthesizer_model  or llm_model),
+    }
+
     if agent_client_factory is None:
         from research_loop.agents.client import make_llm_client
-        agent_client_factory = lambda: make_llm_client(
-            llm_cli, model=llm_model, provider=llm_provider,
-        )
-    client = agent_client_factory()
-    print(f"  LLM client: {getattr(client, 'name', type(client).__name__)}"
-          + (f" model={llm_model}" if llm_model else ""))
+        def _factory(role: str):
+            cli, model = role_config[role]
+            return make_llm_client(cli, model=model, provider=llm_provider)
+        agent_client_factory = _factory
+
+    critic_client = agent_client_factory("critic")
+    author_client = agent_client_factory("author")
+    synthesizer_client = agent_client_factory("synthesizer")
+    for role, c in (("critic", critic_client), ("author", author_client),
+                    ("synthesizer", synthesizer_client)):
+        cli, model = role_config[role]
+        print(f"  {role:12s} → {getattr(c, 'name', type(c).__name__)}"
+              + (f" model={model}" if model else ""))
 
     from research_loop.agents.author import AuthorBAgent
     from research_loop.agents.critic import CriticAgent
     from research_loop.agents.synthesizer import SynthesizerAgent
 
-    critic = CriticAgent(client)
-    author = AuthorBAgent(client)
-    synthesizer = SynthesizerAgent(client)
+    critic = CriticAgent(critic_client)
+    author = AuthorBAgent(author_client)
+    synthesizer = SynthesizerAgent(synthesizer_client)
 
     consecutive_a_wins = 0
     last_round_id: str | None = None
@@ -582,11 +607,25 @@ def main(argv: list[str] | None = None) -> int:
     p_auto.add_argument("--dry-run", action="store_true",
                         help="skip subprocess training; record noop outcomes")
     p_auto.add_argument("--llm-cli", choices=["hermes", "claude", "codex"], default=None,
-                        help="which local LLM CLI to invoke (default: AUTORESEARCH_LLM_CLI env or 'hermes')")
+                        help="default CLI for all 3 roles (env: AUTORESEARCH_LLM_CLI; default 'hermes')")
     p_auto.add_argument("--llm-model", default=None,
-                        help="model name passed to the selected CLI (e.g. 'anthropic/claude-sonnet-4' for hermes)")
+                        help="default model for all 3 roles (e.g. 'anthropic/claude-sonnet-4' for hermes)")
     p_auto.add_argument("--llm-provider", default="auto",
                         help="provider routing for hermes (ignored by claude/codex); default 'auto'")
+    # Per-role overrides — autoreason paper §7.3 supports mixed-model setups
+    # (cheap author + strong judge). Each defaults to the global --llm-cli/--llm-model.
+    p_auto.add_argument("--critic-cli", choices=["hermes", "claude", "codex"], default=None,
+                        help="override CLI for the Critic role (analytical; benefits from a strong model)")
+    p_auto.add_argument("--critic-model", default=None,
+                        help="override model for the Critic role")
+    p_auto.add_argument("--author-cli", choices=["hermes", "claude", "codex"], default=None,
+                        help="override CLI for the Author B role (creative patch generation)")
+    p_auto.add_argument("--author-model", default=None,
+                        help="override model for the Author B role")
+    p_auto.add_argument("--synthesizer-cli", choices=["hermes", "claude", "codex"], default=None,
+                        help="override CLI for the Synthesizer role (conservative AB)")
+    p_auto.add_argument("--synthesizer-model", default=None,
+                        help="override model for the Synthesizer role")
 
     args = p.parse_args(argv)
 
@@ -612,6 +651,12 @@ def main(argv: list[str] | None = None) -> int:
             llm_cli=args.llm_cli,
             llm_model=args.llm_model,
             llm_provider=args.llm_provider,
+            critic_cli=args.critic_cli,
+            critic_model=args.critic_model,
+            author_cli=args.author_cli,
+            author_model=args.author_model,
+            synthesizer_cli=args.synthesizer_cli,
+            synthesizer_model=args.synthesizer_model,
         )
     return 2
 

--- a/research_loop/tournament.py
+++ b/research_loop/tournament.py
@@ -207,6 +207,7 @@ def _outcome_to_candidate_result(outcome: Outcome, candidate: Candidate) -> Cand
         has_rollback=bool(candidate.rollback.strip())
             and candidate.rollback.strip().lower() != "n/a"
             or candidate.kind == "A",
+        status=outcome.status,
     )
 
 
@@ -215,11 +216,12 @@ def cmd_promote(round_id: str) -> int:
     if not candidates:
         print(f"No candidates for round {round_id}", file=sys.stderr)
         return 2
-    outcomes = [o for o in read_outcomes(HISTORY_PATH, round_id=round_id)
-                if o.status == "success"]
+    outcomes = list(read_outcomes(HISTORY_PATH, round_id=round_id))
     if not outcomes:
-        print(f"No successful outcomes for round {round_id}", file=sys.stderr)
+        print(f"No outcomes recorded for round {round_id}", file=sys.stderr)
         return 1
+    # Pass all outcomes (including timeouts) to decide() so the rejection
+    # reasons are visible in the Decision.reason field, not silently filtered.
 
     results = [
         _outcome_to_candidate_result(o, candidates[o.candidate_id])

--- a/research_loop/tournament.py
+++ b/research_loop/tournament.py
@@ -30,6 +30,8 @@ Subcommands:
 from __future__ import annotations
 
 import argparse
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -302,6 +304,82 @@ _TRAINER_PATHS = {
 }
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNS_DIR = Path(__file__).resolve().parent / "runs"
+
+
+def _new_run_id() -> str:
+    """Sortable run id for the run directory."""
+    import time
+    import uuid
+    return f"run{int(time.time())}-{uuid.uuid4().hex[:6]}"
+
+
+class _Tee:
+    """Mirror writes to two streams. Used to send autoreason's narrative print()
+    output to both stdout and run_dir/autoreason.log so external bots (Hermes,
+    Slack) can tail one canonical log path discovered via summary.json.
+    """
+
+    def __init__(self, primary, secondary):
+        self.primary = primary
+        self.secondary = secondary
+
+    def write(self, s):
+        self.primary.write(s)
+        self.primary.flush()
+        self.secondary.write(s)
+        self.secondary.flush()
+        return len(s)
+
+    def flush(self):
+        self.primary.flush()
+        self.secondary.flush()
+
+    def isatty(self):
+        return getattr(self.primary, "isatty", lambda: False)()
+
+    def fileno(self):  # subprocess sometimes asks
+        return self.primary.fileno()
+
+
+def _write_run_summary(
+    run_dir: Path,
+    *,
+    run_id: str,
+    target: str,
+    started_at: str,
+    pass_index: int,
+    max_passes: int,
+    consecutive_a_wins: int,
+    convergence: int,
+    last_decision: dict | None,
+    best_so_far: dict | None,
+    latest_critique_summary: str,
+    status: str,
+) -> None:
+    """Atomic JSON dump consumed by `tournament status` and external bots.
+
+    Atomic via temp + rename so a concurrent reader never sees a half-written file.
+    """
+    import json
+    payload = {
+        "run_id": run_id,
+        "target": target,
+        "started_at": started_at,
+        "current_pass": pass_index,
+        "max_passes": max_passes,
+        "consecutive_a_wins": consecutive_a_wins,
+        "convergence_threshold": convergence,
+        "last_decision": last_decision,
+        "best_so_far": best_so_far,
+        "latest_critique_summary": latest_critique_summary,
+        "status": status,
+    }
+    run_dir.mkdir(parents=True, exist_ok=True)
+    summary = run_dir / "summary.json"
+    tmp = summary.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, indent=2))
+    tmp.replace(summary)
 
 
 def _read_trainer(target: str) -> tuple[str, str]:
@@ -333,7 +411,6 @@ def _read_recent_outcomes_jsonl(target: str, n: int = 10) -> str:
 
 def _git_status_clean(repo: Path) -> bool:
     """Return True iff `git status --porcelain` is empty in `repo`."""
-    import subprocess
     res = subprocess.run(
         ["git", "status", "--porcelain"],
         cwd=repo, capture_output=True, text=True, check=False,
@@ -422,8 +499,53 @@ def cmd_autoreason(
     author = AuthorBAgent(author_client)
     synthesizer = SynthesizerAgent(synthesizer_client)
 
+    # Run-level state for the status surface (Slice 1 of T9)
+    import datetime
+    run_id = _new_run_id()
+    run_dir = RUNS_DIR / run_id
+    started_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    current_pointer = RUNS_DIR / f"{target}_CURRENT.txt"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    current_pointer.write_text(run_id)
+
+    # Mirror cmd_autoreason's narrative output to run_dir/autoreason.log so
+    # external tooling (Hermes, Slack bots, the `tournament status` command)
+    # can tail one canonical path discovered via summary.json. Operators who
+    # also nohup-redirect get duplicate output — that's fine.
+    # Write PID file for `tournament status` to detect alive vs exited
+    (run_dir / "autoreason.pid").write_text(str(os.getpid()))
+
+    narrative_log_path = run_dir / "autoreason.log"
+    _log_fh = open(narrative_log_path, "a", buffering=1)
+    _orig_stdout, _orig_stderr = sys.stdout, sys.stderr
+    sys.stdout = _Tee(_orig_stdout, _log_fh)
+    sys.stderr = _Tee(_orig_stderr, _log_fh)
+
+    def _close_narrative_log() -> None:
+        sys.stdout, sys.stderr = _orig_stdout, _orig_stderr
+        _log_fh.close()
+
+    def _status_dump(
+        pass_index: int, status: str, latest_critique: str = "",
+        last_decision_dict: dict | None = None, best: dict | None = None,
+    ) -> None:
+        _write_run_summary(
+            run_dir, run_id=run_id, target=target, started_at=started_at,
+            pass_index=pass_index, max_passes=max_passes,
+            consecutive_a_wins=consecutive_a_wins, convergence=convergence,
+            last_decision=last_decision_dict, best_so_far=best,
+            latest_critique_summary=latest_critique, status=status,
+        )
+
     consecutive_a_wins = 0
     last_round_id: str | None = None
+    latest_critique_text = ""
+    last_decision_dict: dict | None = None
+    best_so_far: dict | None = None
+
+    _status_dump(0, "starting")
+    print(f"  run_id: {run_id}")
+    print(f"  status: {run_dir}/summary.json")
 
     for pass_index in range(1, max_passes + 1):
         print(f"\n=== autoreason pass {pass_index}/{max_passes} ===")
@@ -535,12 +657,16 @@ def cmd_autoreason(
         rc = cmd_promote(round_id)
         if rc != 0:
             print(f"  promote failed for round {round_id}", file=sys.stderr)
+            _status_dump(pass_index, "promote_failed", latest_critique_text, last_decision_dict, best_so_far)
+            _close_narrative_log()
             return rc
 
         # 7. Convergence check
         decisions = [d for d in __import__("research_loop.candidate", fromlist=["read_decisions"]).read_decisions(HISTORY_PATH, round_id=round_id)]
         if not decisions:
             print(f"  no decision recorded for round {round_id}", file=sys.stderr)
+            _status_dump(pass_index, "no_decision", latest_critique_text, last_decision_dict, best_so_far)
+            _close_narrative_log()
             return 1
         decision = decisions[-1]
         if decision.winner_kind == "A":
@@ -548,14 +674,168 @@ def cmd_autoreason(
         else:
             consecutive_a_wins = 0
         last_round_id = round_id
+        latest_critique_text = critique.summary
+        last_decision_dict = {
+            "round_id": decision.round_id,
+            "winner_id": decision.winner_id,
+            "winner_kind": decision.winner_kind,
+            "promote": decision.promote,
+            "deployable": decision.deployable,
+            "reason": decision.reason,
+        }
+        # Best so far: pull from the freshest A or B/AB outcome we've seen
+        from research_loop.candidate import read_outcomes as _ro
+        all_outcomes = list(_ro(HISTORY_PATH))
+        best_so_far = None
+        for o in reversed(all_outcomes):
+            if o.target != target or o.status != "success" or not o.metrics:
+                continue
+            if best_so_far is None or o.metrics.get("combined", 0) > best_so_far.get("combined", 0):
+                best_so_far = dict(o.metrics)
+        _status_dump(pass_index, "running", latest_critique_text, last_decision_dict, best_so_far)
         print(f"  decision: winner={decision.winner_kind}, consecutive A={consecutive_a_wins}/{convergence}")
 
         if consecutive_a_wins >= convergence:
             print(f"\nConverged at pass {pass_index} (A won {convergence} consecutive rounds).")
+            _status_dump(pass_index, "converged", latest_critique_text, last_decision_dict, best_so_far)
+            _close_narrative_log()
             return 0
 
     print(f"\nMax passes ({max_passes}) reached without convergence. Last round: {last_round_id}")
+    _status_dump(max_passes, "max_passes_exhausted", latest_critique_text, last_decision_dict, best_so_far)
+    _close_narrative_log()
     return 1
+
+
+# ---------------------------------------------------------------------------
+# status — one-shot human/bot-readable summary of an autoreason run
+# ---------------------------------------------------------------------------
+
+def _format_status(summary: dict, *, run_dir: Path, log_path: Path,
+                   pid_alive: bool | None, etime: str | None,
+                   history_count: int) -> str:
+    """Render summary.json + ambient state into a single readable block.
+    Designed to be `cat`-ed by an external bot (Hermes, Slack) and pasted
+    verbatim back to a user asking "how is training going?".
+    """
+    lines: list[str] = []
+    target = summary.get("target", "?")
+    lines.append(f"autoreason status — {target}")
+    pid_str = "unknown"
+    if pid_alive is True:
+        pid_str = f"alive ({etime or '?'})"
+    elif pid_alive is False:
+        pid_str = "exited"
+    lines.append(f"  Run:          {summary.get('run_id', '?')} ({pid_str})")
+    lines.append(f"  Started:      {summary.get('started_at', '?')}")
+    lines.append(f"  Status:       {summary.get('status', '?')}")
+    pass_idx = summary.get("current_pass", 0)
+    max_p = summary.get("max_passes", "?")
+    a_wins = summary.get("consecutive_a_wins", 0)
+    conv = summary.get("convergence_threshold", "?")
+    lines.append(f"  Pass:         {pass_idx} / {max_p}  (consecutive A wins: {a_wins} / {conv})")
+    last_dec = summary.get("last_decision")
+    if last_dec:
+        lines.append(
+            f"  Last decision: {last_dec.get('winner_kind', '?')} wins "
+            f"({last_dec.get('round_id', '?')}, deployable={last_dec.get('deployable', '?')})"
+        )
+        lines.append(f"                 reason: {last_dec.get('reason', '')[:120]}")
+    best = summary.get("best_so_far")
+    if best:
+        lines.append(
+            f"  Best so far:  combined={best.get('combined', 0):.4f}  "
+            f"recall@1={best.get('recall_1', 0):.4f}  "
+            f"neg_acc={best.get('productness_neg_acc', 0):.4f}"
+        )
+    crit = summary.get("latest_critique_summary", "")
+    if crit:
+        lines.append(f"  Latest critique: {crit[:200]}")
+    lines.append("  Logs:")
+    lines.append(f"    narrative: {log_path}")
+    lines.append(f"    history:   {HISTORY_PATH} ({history_count} records)")
+    lines.append(f"    run dir:   {run_dir}")
+    return "\n".join(lines)
+
+
+def cmd_status(target: str | None = None, run_id: str | None = None) -> int:
+    """Print a one-shot status block — readable by humans and external bots.
+
+    Resolution order for which run to summarize:
+      1. explicit --run RUN_ID
+      2. --target TARGET → CURRENT pointer for that target
+      3. most recently mtime'd run dir under research_loop/runs/
+
+    Exit codes:
+      0  found a run, printed status
+      2  no run found
+    """
+    import json
+    if not RUNS_DIR.exists():
+        print(f"No runs directory at {RUNS_DIR}", file=sys.stderr)
+        return 2
+
+    # Resolve run_dir
+    chosen_run_dir: Path | None = None
+    if run_id:
+        candidate = RUNS_DIR / run_id
+        if candidate.is_dir():
+            chosen_run_dir = candidate
+    elif target:
+        pointer = RUNS_DIR / f"{target}_CURRENT.txt"
+        if pointer.exists():
+            chosen_run_dir = RUNS_DIR / pointer.read_text().strip()
+    else:
+        # Newest mtime wins
+        run_dirs = [d for d in RUNS_DIR.iterdir() if d.is_dir()]
+        if run_dirs:
+            chosen_run_dir = max(run_dirs, key=lambda d: d.stat().st_mtime)
+
+    if chosen_run_dir is None or not chosen_run_dir.is_dir():
+        print(f"No autoreason run found (target={target}, run_id={run_id})", file=sys.stderr)
+        return 2
+
+    summary_path = chosen_run_dir / "summary.json"
+    if not summary_path.exists():
+        print(f"Run dir {chosen_run_dir} has no summary.json yet", file=sys.stderr)
+        return 2
+
+    summary = json.loads(summary_path.read_text())
+
+    # Best-effort process check — if a PID was recorded, see if it's alive.
+    pid_alive: bool | None = None
+    etime: str | None = None
+    pid_path = chosen_run_dir / "autoreason.pid"
+    if pid_path.exists():
+        try:
+            pid = int(pid_path.read_text().strip())
+            import os
+            os.kill(pid, 0)
+            pid_alive = True
+            try:
+                ps = subprocess.run(
+                    ["ps", "-p", str(pid), "-o", "etime="],
+                    capture_output=True, text=True, check=False,
+                )
+                etime = ps.stdout.strip() or None
+            except Exception:
+                pass
+        except (ProcessLookupError, ValueError, PermissionError):
+            pid_alive = False
+
+    history_count = 0
+    if HISTORY_PATH.exists():
+        history_count = sum(1 for _ in HISTORY_PATH.open() if _.strip())
+
+    print(_format_status(
+        summary,
+        run_dir=chosen_run_dir,
+        log_path=chosen_run_dir / "autoreason.log",
+        pid_alive=pid_alive,
+        etime=etime,
+        history_count=history_count,
+    ))
+    return 0
 
 
 # ---------------------------------------------------------------------------
@@ -592,6 +872,13 @@ def main(argv: list[str] | None = None) -> int:
     p_round.add_argument("--baseline-only", action="store_true",
                          help="run only the A (incumbent baseline); useful for first run")
     p_round.add_argument("--dry-run", action="store_true")
+
+    p_status = sub.add_parser("status",
+        help="one-shot 'how is autoreason going?' summary (for humans + Slack bots)")
+    p_status.add_argument("--target", choices=["student_v2", "dino_v2"], default=None,
+                          help="resolve via runs/<target>_CURRENT.txt")
+    p_status.add_argument("--run", default=None,
+                          help="explicit run_id (overrides --target)")
 
     p_auto = sub.add_parser("autoreason",
         help="fully-autonomous LLM-driven loop (Critic + Author B + Synthesizer)")
@@ -640,6 +927,8 @@ def main(argv: list[str] | None = None) -> int:
     if args.cmd == "run-round":
         return cmd_run_round(args.target, args.hypothesis, args.epochs,
                              baseline_only=args.baseline_only, dry_run=args.dry_run)
+    if args.cmd == "status":
+        return cmd_status(target=args.target, run_id=args.run)
     if args.cmd == "autoreason":
         return cmd_autoreason(
             args.target,

--- a/research_loop/tournament.py
+++ b/research_loop/tournament.py
@@ -35,8 +35,11 @@ from pathlib import Path
 
 from research_loop.candidate import (
     Candidate,
+    CritiqueRecord,
     Decision,
     Outcome,
+    PatchProposalRecord,
+    SynthesisRecord,
     append_history,
     find_candidate,
     new_round_id,
@@ -44,6 +47,7 @@ from research_loop.candidate import (
     read_outcomes,
 )
 from research_loop.judges import rank as rank_candidates
+from research_loop.patch import apply_patch
 from research_loop.promote import (
     CandidateResult,
     decide,
@@ -288,6 +292,238 @@ def cmd_run_round(target: str, hypothesis: str, epochs: int | None,
 
 
 # ---------------------------------------------------------------------------
+# autoreason — fully autonomous LLM-driven loop
+# ---------------------------------------------------------------------------
+
+# Trainer source paths each target's Author B agent should patch.
+_TRAINER_PATHS = {
+    "student_v2": "student_finetune/train_v2.py",
+    "dino_v2":    "dino_finetune/train_dino_v2.py",
+}
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read_trainer(target: str) -> tuple[str, str]:
+    """Return (trainer_source, trainer_repo_relative_path) for the target."""
+    rel = _TRAINER_PATHS[target]
+    return (REPO_ROOT / rel).read_text(), rel
+
+
+def _read_results_tail(target: str, n_rows: int = 30) -> str:
+    """Last N rows of the target's results_v2.tsv (header + tail), or '' if missing."""
+    path = TARGETS[target]().RESULTS_TSV
+    if not path.exists():
+        return ""
+    lines = path.read_text().splitlines()
+    if not lines:
+        return ""
+    header = lines[0]
+    tail = lines[-n_rows:]
+    if tail and tail[0] == header:
+        return "\n".join(tail)
+    return "\n".join([header] + tail)
+
+
+def _read_recent_outcomes_jsonl(target: str, n: int = 10) -> str:
+    """Last N outcome JSONL records for the target, newest-first becomes oldest-first."""
+    relevant = [o for o in read_outcomes(HISTORY_PATH) if o.target == target]
+    return "\n".join(o.to_jsonl() for o in relevant[-n:])
+
+
+def _git_status_clean(repo: Path) -> bool:
+    """Return True iff `git status --porcelain` is empty in `repo`."""
+    import subprocess
+    res = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=repo, capture_output=True, text=True, check=False,
+    )
+    return res.returncode == 0 and not res.stdout.strip()
+
+
+def cmd_autoreason(
+    target: str,
+    *,
+    max_passes: int,
+    convergence: int,
+    max_seconds_per_candidate: float | None,
+    hypothesis_seed: str,
+    dry_run: bool,
+    agent_client_factory=None,
+) -> int:
+    """Fully autonomous autoreason loop.
+
+    Each pass: fresh Critic → fresh Author B → fresh Synthesizer → run A/B/AB
+    via the target adapter (under per-candidate time budget) → promote.decide().
+    Winner becomes the new A; loop terminates after `convergence` consecutive
+    A wins or after `max_passes` total passes.
+
+    `agent_client_factory` is injected for testing — production passes None
+    and we construct a real AgentClient.
+    """
+    if target not in TARGETS:
+        print(f"Unknown target: {target}", file=sys.stderr)
+        return 2
+
+    if not dry_run and not _git_status_clean(REPO_ROOT):
+        print(
+            "Working tree is dirty. autoreason will apply and revert patches "
+            "via `git apply`; commit or stash uncommitted changes before running.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Lazy-construct the AgentClient so dry-run / tests don't need API keys.
+    if agent_client_factory is None:
+        from research_loop.agents.client import AgentClient
+        agent_client_factory = AgentClient
+    client = agent_client_factory()
+
+    from research_loop.agents.author import AuthorBAgent
+    from research_loop.agents.critic import CriticAgent
+    from research_loop.agents.synthesizer import SynthesizerAgent
+
+    critic = CriticAgent(client)
+    author = AuthorBAgent(client)
+    synthesizer = SynthesizerAgent(client)
+
+    consecutive_a_wins = 0
+    last_round_id: str | None = None
+
+    for pass_index in range(1, max_passes + 1):
+        print(f"\n=== autoreason pass {pass_index}/{max_passes} ===")
+        round_id = new_round_id()
+
+        trainer_source, trainer_path = _read_trainer(target)
+        results_tail = _read_results_tail(target)
+        recent_outcomes = _read_recent_outcomes_jsonl(target)
+
+        # 1. Critic
+        critique = critic.critique(
+            trainer_source=trainer_source,
+            results_tsv_tail=results_tail,
+            recent_outcomes_json=recent_outcomes,
+        )
+        append_history(HISTORY_PATH, CritiqueRecord(
+            round_id=round_id, target=target, pass_index=pass_index,
+            summary=critique.summary, problems=critique.problems, raw=critique.raw,
+        ))
+        print(f"  critic: {len(critique.problems)} problem(s) found")
+
+        # 2. Author B
+        b_proposal = author.author(
+            trainer_source=trainer_source,
+            trainer_path=trainer_path,
+            critique_text=critique.raw,
+        )
+
+        # 3. Synthesizer (sees only patches, anonymized labels)
+        ab_synthesis = synthesizer.synthesize(
+            patch_x="", patch_y=b_proposal.diff,  # X=A=empty (do-nothing); Y=B
+            trainer_path=trainer_path,
+        )
+
+        # 4. Build A / B / AB Candidate records for this round
+        a_candidate = _make_baseline_a(target, round_id, hypothesis_seed)
+        b_candidate = Candidate(
+            kind="B", target=target, round_id=round_id,
+            hypothesis=critique.summary[:200] or "Address critic findings",
+            expected_metric="combined Δ > 0.003 (TBD by run)",
+            changed_files=[trainer_path] if b_proposal.diff else [],
+            risks=critique.problems[:3] or ["LLM-generated patch — unverified"],
+            rollback="combined regresses below incumbent by > 0.005",
+            patch=b_proposal.diff or "--- a/_noop\n+++ b/_noop\n",
+            parent_incumbent_id=a_candidate.id,
+        ) if b_proposal.diff else None
+        ab_candidate = Candidate(
+            kind="AB", target=target, round_id=round_id,
+            hypothesis="Conservative synthesis of A and B",
+            expected_metric="combined Δ > 0.003 (TBD by run)",
+            changed_files=[trainer_path] if ab_synthesis.diff else [],
+            risks=["synthesis-only"],
+            rollback="combined regresses below incumbent by > 0.005",
+            patch=ab_synthesis.diff or "--- a/_noop\n+++ b/_noop\n",
+            parent_incumbent_id=a_candidate.id,
+        ) if ab_synthesis.diff else None
+
+        for c in (a_candidate, b_candidate, ab_candidate):
+            if c is not None:
+                append_history(HISTORY_PATH, c)
+
+        # Audit-trail records for the LLM calls
+        if b_candidate is not None:
+            append_history(HISTORY_PATH, PatchProposalRecord(
+                round_id=round_id, target=target, pass_index=pass_index,
+                candidate_id=b_candidate.id,
+                rationale=b_proposal.rationale, diff=b_proposal.diff,
+                raw=b_proposal.raw,
+            ))
+        if ab_candidate is not None:
+            append_history(HISTORY_PATH, SynthesisRecord(
+                round_id=round_id, target=target, pass_index=pass_index,
+                candidate_id=ab_candidate.id,
+                rationale=ab_synthesis.rationale, diff=ab_synthesis.diff,
+                raw=ab_synthesis.raw,
+            ))
+
+        # 5. Run A / B / AB. A is do-nothing — we still need its outcome
+        # (first pass: real training run; later passes: reuse last A's outcome).
+        candidates_to_run = [a_candidate]
+        if b_candidate is not None:
+            candidates_to_run.append(b_candidate)
+        if ab_candidate is not None:
+            candidates_to_run.append(ab_candidate)
+
+        for cand in candidates_to_run:
+            print(f"  running {cand.kind} ({cand.id})")
+            adapter = TARGETS[target]()
+            adapter.apply_patch(cand)  # validates V1-safety; no-op for A
+            if cand.kind == "A" or not cand.patch.strip():
+                # Empty patch = no working-tree change
+                outcome = adapter.train(cand, max_seconds=max_seconds_per_candidate, dry_run=dry_run)
+            else:
+                with apply_patch(cand.patch, repo=REPO_ROOT, require_clean_tree=False):
+                    outcome = adapter.train(cand, max_seconds=max_seconds_per_candidate, dry_run=dry_run)
+            outcome_record = Outcome(
+                candidate_id=cand.id, round_id=round_id, target=target,
+                status=outcome.status, metrics=outcome.metrics,
+                elapsed_seconds=outcome.elapsed_seconds,
+                log_path=str(outcome.log_path),
+                metrics_json_path=str(outcome.metrics_json_path),
+            )
+            append_history(HISTORY_PATH, outcome_record)
+            if not dry_run and outcome.status == "success":
+                adapter.log_row(cand, outcome)
+            print(f"    status={outcome.status}")
+
+        # 6. Promote — A vs B vs AB under guardrails
+        rc = cmd_promote(round_id)
+        if rc != 0:
+            print(f"  promote failed for round {round_id}", file=sys.stderr)
+            return rc
+
+        # 7. Convergence check
+        decisions = [d for d in __import__("research_loop.candidate", fromlist=["read_decisions"]).read_decisions(HISTORY_PATH, round_id=round_id)]
+        if not decisions:
+            print(f"  no decision recorded for round {round_id}", file=sys.stderr)
+            return 1
+        decision = decisions[-1]
+        if decision.winner_kind == "A":
+            consecutive_a_wins += 1
+        else:
+            consecutive_a_wins = 0
+        last_round_id = round_id
+        print(f"  decision: winner={decision.winner_kind}, consecutive A={consecutive_a_wins}/{convergence}")
+
+        if consecutive_a_wins >= convergence:
+            print(f"\nConverged at pass {pass_index} (A won {convergence} consecutive rounds).")
+            return 0
+
+    print(f"\nMax passes ({max_passes}) reached without convergence. Last round: {last_round_id}")
+    return 1
+
+
+# ---------------------------------------------------------------------------
 # main
 # ---------------------------------------------------------------------------
 
@@ -322,6 +558,20 @@ def main(argv: list[str] | None = None) -> int:
                          help="run only the A (incumbent baseline); useful for first run")
     p_round.add_argument("--dry-run", action="store_true")
 
+    p_auto = sub.add_parser("autoreason",
+        help="fully-autonomous LLM-driven loop (Critic + Author B + Synthesizer)")
+    p_auto.add_argument("--target", required=True, choices=list(TARGETS))
+    p_auto.add_argument("--max-passes", type=int, default=15,
+                        help="ceiling on number of refinement passes (default 15)")
+    p_auto.add_argument("--convergence", type=int, default=2,
+                        help="terminate after this many consecutive A wins (default 2)")
+    p_auto.add_argument("--max-seconds-per-candidate", type=float, default=None,
+                        help="kill any single candidate's training after N seconds (recommended)")
+    p_auto.add_argument("--hypothesis-seed", default="autoreason refinement loop",
+                        help="initial hypothesis context shown to A baseline")
+    p_auto.add_argument("--dry-run", action="store_true",
+                        help="skip subprocess training; record noop outcomes")
+
     args = p.parse_args(argv)
 
     if args.cmd == "propose":
@@ -335,6 +585,15 @@ def main(argv: list[str] | None = None) -> int:
     if args.cmd == "run-round":
         return cmd_run_round(args.target, args.hypothesis, args.epochs,
                              baseline_only=args.baseline_only, dry_run=args.dry_run)
+    if args.cmd == "autoreason":
+        return cmd_autoreason(
+            args.target,
+            max_passes=args.max_passes,
+            convergence=args.convergence,
+            max_seconds_per_candidate=args.max_seconds_per_candidate,
+            hypothesis_seed=args.hypothesis_seed,
+            dry_run=args.dry_run,
+        )
     return 2
 
 

--- a/research_loop/tournament.py
+++ b/research_loop/tournament.py
@@ -349,6 +349,9 @@ def cmd_autoreason(
     max_seconds_per_candidate: float | None,
     hypothesis_seed: str,
     dry_run: bool,
+    llm_cli: str | None = None,
+    llm_model: str | None = None,
+    llm_provider: str = "auto",
     agent_client_factory=None,
 ) -> int:
     """Fully autonomous autoreason loop.
@@ -358,8 +361,12 @@ def cmd_autoreason(
     Winner becomes the new A; loop terminates after `convergence` consecutive
     A wins or after `max_passes` total passes.
 
-    `agent_client_factory` is injected for testing — production passes None
-    and we construct a real AgentClient.
+    LLM access is via subprocess to a local CLI (hermes / claude / codex).
+    `llm_cli` defaults to AUTORESEARCH_LLM_CLI env or "hermes". `llm_model`
+    is passed through to whichever CLI is selected.
+
+    `agent_client_factory` is injected for testing — production callers pass
+    None and we construct a real CLI-backed client.
     """
     if target not in TARGETS:
         print(f"Unknown target: {target}", file=sys.stderr)
@@ -373,11 +380,14 @@ def cmd_autoreason(
         )
         return 2
 
-    # Lazy-construct the AgentClient so dry-run / tests don't need API keys.
     if agent_client_factory is None:
-        from research_loop.agents.client import AgentClient
-        agent_client_factory = AgentClient
+        from research_loop.agents.client import make_llm_client
+        agent_client_factory = lambda: make_llm_client(
+            llm_cli, model=llm_model, provider=llm_provider,
+        )
     client = agent_client_factory()
+    print(f"  LLM client: {getattr(client, 'name', type(client).__name__)}"
+          + (f" model={llm_model}" if llm_model else ""))
 
     from research_loop.agents.author import AuthorBAgent
     from research_loop.agents.critic import CriticAgent
@@ -571,6 +581,12 @@ def main(argv: list[str] | None = None) -> int:
                         help="initial hypothesis context shown to A baseline")
     p_auto.add_argument("--dry-run", action="store_true",
                         help="skip subprocess training; record noop outcomes")
+    p_auto.add_argument("--llm-cli", choices=["hermes", "claude", "codex"], default=None,
+                        help="which local LLM CLI to invoke (default: AUTORESEARCH_LLM_CLI env or 'hermes')")
+    p_auto.add_argument("--llm-model", default=None,
+                        help="model name passed to the selected CLI (e.g. 'anthropic/claude-sonnet-4' for hermes)")
+    p_auto.add_argument("--llm-provider", default="auto",
+                        help="provider routing for hermes (ignored by claude/codex); default 'auto'")
 
     args = p.parse_args(argv)
 
@@ -593,6 +609,9 @@ def main(argv: list[str] | None = None) -> int:
             max_seconds_per_candidate=args.max_seconds_per_candidate,
             hypothesis_seed=args.hypothesis_seed,
             dry_run=args.dry_run,
+            llm_cli=args.llm_cli,
+            llm_model=args.llm_model,
+            llm_provider=args.llm_provider,
         )
     return 2
 

--- a/student_finetune/tests/test_metrics_progress_write.py
+++ b/student_finetune/tests/test_metrics_progress_write.py
@@ -1,0 +1,85 @@
+"""T1 verification: metrics_progress_v2.json atomic write contract.
+
+We don't run a full training cycle (that's a GPU run). We test the pure
+helper function and its atomic-rename behavior in a tmp dir.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from train_v2 import write_metrics_progress  # noqa: E402
+
+
+REQUIRED_KEYS = {
+    "status", "version", "is_partial", "epochs_completed", "max_epochs",
+    "combined_metric", "best_combined", "recall_at_1", "recall_at_5",
+    "mean_cosine", "distill_loss",
+    "productness_train_loss", "productness_train_acc",
+    "productness_val_loss", "productness_val_acc",
+    "productness_pos_acc", "productness_neg_acc",
+}
+
+
+def _full_kwargs():
+    return dict(
+        epoch=4, max_epochs=30,
+        combined=0.79, recall_at_1=0.89, recall_at_5=0.94,
+        mean_cosine=0.69, best_combined=0.79, distill_loss=0.31,
+        productness_train_loss=0.08, productness_train_acc=0.96,
+        productness_val_loss=0.45, productness_val_acc=0.84,
+        productness_pos_acc=0.99, productness_neg_acc=0.81,
+    )
+
+
+def test_writes_valid_json_with_required_schema(tmp_path: Path):
+    write_metrics_progress(tmp_path, **_full_kwargs())
+    p = tmp_path / "metrics_progress_v2.json"
+    assert p.exists()
+    payload = json.loads(p.read_text())
+    assert set(payload.keys()) >= REQUIRED_KEYS
+    assert payload["is_partial"] is True
+    assert payload["status"] == "in_progress"
+
+
+def test_epochs_completed_is_one_indexed(tmp_path: Path):
+    """epoch=4 (0-indexed loop counter) → epochs_completed=5 (human readable)."""
+    kw = _full_kwargs()
+    kw["epoch"] = 4
+    write_metrics_progress(tmp_path, **kw)
+    payload = json.loads((tmp_path / "metrics_progress_v2.json").read_text())
+    assert payload["epochs_completed"] == 5
+
+
+def test_atomic_replace_overwrites_existing(tmp_path: Path):
+    """Second write replaces first — atomic via temp+rename."""
+    kw = _full_kwargs()
+    write_metrics_progress(tmp_path, **kw)
+    kw["combined"] = 0.83
+    kw["epoch"] = 9
+    write_metrics_progress(tmp_path, **kw)
+    payload = json.loads((tmp_path / "metrics_progress_v2.json").read_text())
+    assert payload["combined_metric"] == 0.83
+    assert payload["epochs_completed"] == 10
+
+
+def test_no_tmp_file_left_after_successful_write(tmp_path: Path):
+    """Atomic rename should leave no .tmp file on disk."""
+    write_metrics_progress(tmp_path, **_full_kwargs())
+    leftovers = list(tmp_path.glob("*.tmp"))
+    assert leftovers == []
+
+
+def test_all_numeric_values_serialize_as_json_numbers(tmp_path: Path):
+    """Floats must serialize as JSON numbers, not strings."""
+    write_metrics_progress(tmp_path, **_full_kwargs())
+    raw = (tmp_path / "metrics_progress_v2.json").read_text()
+    # Quick sanity: combined_metric must NOT be quoted
+    assert '"combined_metric": 0.79' in raw
+    assert '"is_partial": true' in raw  # JSON true, not Python True

--- a/student_finetune/train_v2.py
+++ b/student_finetune/train_v2.py
@@ -179,6 +179,60 @@ class ProductnessLCNet(LCNet):
         return self.productness_head(summary).squeeze(-1)
 
 
+def write_metrics_progress(
+    out_dir: Path,
+    *,
+    epoch: int,
+    max_epochs: int,
+    combined: float,
+    recall_at_1: float,
+    recall_at_5: float,
+    mean_cosine: float,
+    best_combined: float,
+    distill_loss: float,
+    productness_train_loss: float = 0.0,
+    productness_train_acc: float = 0.0,
+    productness_val_loss: float = 0.0,
+    productness_val_acc: float = 0.0,
+    productness_pos_acc: float = 0.0,
+    productness_neg_acc: float = 0.0,
+) -> None:
+    """Write metrics_progress_v2.json atomically after each eval cycle.
+
+    Same schema as metrics_final_v2.json plus is_partial=True and
+    epochs_completed. Atomic write (tmp + rename) avoids race conditions
+    when an external timeout signals while we're flushing.
+
+    Used by tournament adapters to recover partial state on `--max-seconds`
+    timeouts so a candidate that didn't finish still has interpretable
+    metrics for promote.decide() (which then rejects it as a timeout
+    regardless of values).
+    """
+    payload = {
+        "status": "in_progress",
+        "version": "v2",
+        "is_partial": True,
+        "epochs_completed": int(epoch + 1),  # 1-indexed for human readers
+        "max_epochs": int(max_epochs),
+        "combined_metric": float(combined),
+        "best_combined": float(best_combined),
+        "recall_at_1": float(recall_at_1),
+        "recall_at_5": float(recall_at_5),
+        "mean_cosine": float(mean_cosine),
+        "distill_loss": float(distill_loss),
+        "productness_train_loss": float(productness_train_loss),
+        "productness_train_acc": float(productness_train_acc),
+        "productness_val_loss": float(productness_val_loss),
+        "productness_val_acc": float(productness_val_acc),
+        "productness_pos_acc": float(productness_pos_acc),
+        "productness_neg_acc": float(productness_neg_acc),
+    }
+    progress_path = out_dir / "metrics_progress_v2.json"
+    tmp_path = progress_path.with_suffix(".json.tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2))
+    tmp_path.replace(progress_path)  # atomic on POSIX
+
+
 def _adapter_sha8(adapter_dir: Path) -> str:
     """Stable 8-char identifier for a LoRA adapter, derived from its weights file.
 
@@ -817,6 +871,8 @@ def main(max_epochs: int, patience: int, swa_epochs: int, resume: bool) -> None:
             f"loss={stats.loss:.4f} distill={stats.distill_loss:.4f} "
             f"arc={stats.arc_loss:.4f} cosine={stats.mean_cosine:.4f}{arc_str} | {epoch_time:.1f}s"
         )
+        # Productness eval (defaults so progress write doesn't depend on flag)
+        productness_val: dict = {"loss": 0.0, "acc": 0.0, "pos_acc": 0.0, "neg_acc": 0.0, "n": 0}
         if USE_PRODUCTNESS_CLS:
             logger.info(
                 f"  Productness (train): loss={stats.productness_loss:.4f} "
@@ -824,7 +880,7 @@ def main(max_epochs: int, patience: int, swa_epochs: int, resume: bool) -> None:
                 f"pos_acc={stats.productness_pos_acc:.4f} neg_acc={stats.productness_neg_acc:.4f} "
                 f"(n={stats.productness_n})"
             )
-            val_metrics = eval_productness(
+            productness_val = eval_productness(
                 model=model,
                 val_paths=productness_val_paths,
                 negative_paths=collect_negative_paths(REID_NEGATIVES),
@@ -833,10 +889,10 @@ def main(max_epochs: int, patience: int, swa_epochs: int, resume: bool) -> None:
                 batch_size=BATCH_SIZE,
             )
             logger.info(
-                f"  Productness (val):   loss={val_metrics['loss']:.4f} "
-                f"acc={val_metrics['acc']:.4f} "
-                f"pos_acc={val_metrics['pos_acc']:.4f} neg_acc={val_metrics['neg_acc']:.4f} "
-                f"(n={val_metrics['n']})"
+                f"  Productness (val):   loss={productness_val['loss']:.4f} "
+                f"acc={productness_val['acc']:.4f} "
+                f"pos_acc={productness_val['pos_acc']:.4f} neg_acc={productness_val['neg_acc']:.4f} "
+                f"(n={productness_val['n']})"
             )
 
         # SWA
@@ -866,6 +922,25 @@ def main(max_epochs: int, patience: int, swa_epochs: int, resume: bool) -> None:
 
         combined = compute_combined_metric(recall_at_1, mean_cos)
         logger.info(f"  Combined: {combined:.6f} (best={best_combined:.6f})")
+
+        # Atomic partial-state dump for tournament timeout recovery (T1)
+        write_metrics_progress(
+            out_dir,
+            epoch=epoch,
+            max_epochs=max_epochs,
+            combined=combined,
+            recall_at_1=recall_at_1,
+            recall_at_5=recall_at_5,
+            mean_cosine=mean_cos,
+            best_combined=max(best_combined, combined),
+            distill_loss=stats.distill_loss,
+            productness_train_loss=stats.productness_loss,
+            productness_train_acc=stats.productness_acc,
+            productness_val_loss=productness_val["loss"],
+            productness_val_acc=productness_val["acc"],
+            productness_pos_acc=productness_val.get("pos_acc", 0.0),
+            productness_neg_acc=productness_val.get("neg_acc", 0.0),
+        )
 
         # Save last + best
         save_checkpoint(


### PR DESCRIPTION
Closes #11. Closes #10 (time-budget primitive landed as T2 of this PR).

## TL;DR

PR #8 shipped the research_loop **evaluation/execution** layer (Candidate / Outcome / Decision schema, V2-only target adapters, productness-aware promotion guardrails, tournament CLI). What it lacked was the **generation** layer — the autoreason paper's core insight is that fresh LLM agents (Critic / Author B / Synthesizer) drive proposals automatically. Without that, every B/AB candidate's patch was a `# TODO` placeholder a human had to fill in, and the user correctly observed *"this completely doesn't match autoreason — autoreason has no human intervention."*

This PR closes that gap. After merge, `tournament autoreason --target student_v2 --max-passes 15 --max-seconds-per-candidate 9000` runs the full Critic → Author B → Synthesizer → train-under-budget → promote → repeat-until-k=2 cycle without human intervention.

## What's implemented

8 atomic commits, one per task in [TASKS-AUTOREASON.md](TASKS-AUTOREASON.md):

```
5608c8c  docs(handoff): real-LLM smoke script + T8 procedure
a8ea488  docs(handoff): replace run-round with autonomous tournament autoreason flow
1375573  feat(research_loop): autoreason convergence loop + tournament autoreason CLI
87ecd9a  feat(agents): Critic / Author B / Synthesizer with typed dataclass results
46f30db  feat(agents): Anthropic SDK wrapper with prompt caching
86c9fd8  feat(research_loop): patch applicator with V1 safety + revert-on-exit
223025d  feat(research_loop): per-trial time budget via adapter.train(max_seconds=N)
908cda8  feat(trainers): write metrics_progress_v2.json after each eval for timeout recovery
```

Plus 3 planning commits: SPEC-AUTOREASON.md, PLAN-AUTOREASON.md, TASKS-AUTOREASON.md.

### Primitives (T1–T3)

- **`metrics_progress_v2.json`** written atomically after every eval cycle in both V2 trainers — gives timeout recovery a partial-state file to read.
- **`adapter.train(max_seconds=N)`** SIGTERM/30s-grace/SIGKILL with partial-metric recovery. `Outcome.status="timeout"`. `promote.decide()` rejects timeout candidates regardless of metric values.
- **`research_loop/patch.py`** context-manager applies unified diffs via `git apply` and reverts on exit. Refuses any path matching `V1_FORBIDDEN_PATHS` *before* mutation. Empty diff = no-op (kind=A semantics). Dirty working tree refused.

### Agents (T4–T5)

- **`AgentClient`** — single shared `anthropic.Anthropic()` wrapper. System prompts ship with `cache_control: ephemeral`. API key from `ANTHROPIC_API_KEY` env or `~/.hermes/.env`. Default model `claude-sonnet-4-6`. Each `.call()` is fresh single-shot (no chat history persisted).
- **`CriticAgent`** — finds problems only, no fixes proposed (autoreason §2). Reads trainer + last 30 results_v2.tsv rows + last 10 outcomes. Returns `Critique(summary, problems, raw)`. Temperature 0.3 (consistency).
- **`AuthorBAgent`** — produces unified diff addressing critic findings. System prompt explicitly enumerates V1_FORBIDDEN_PATHS (defense in depth). Returns `PatchProposal(rationale, diff, raw)`. Temperature 0.8 (diverse revisions).
- **`SynthesizerAgent`** — sees patches with anonymized X/Y labels (autoreason §2), no metric history (project decision 2026-04-25). Conservative synthesis principles in prompt (smallest-subset, halve magnitudes, prefer additions, willing to NO_PATCH).

### Convergence loop + CLI (T6)

- **`tournament autoreason`** subcommand. Each pass: read trainer + history → Critic → Author B → Synthesizer → for each kind ∈ {A,B,AB}: `apply_patch` (auto-revert) → `adapter.train(max_seconds)` → write Outcome → `promote.decide()` → write Decision. Convergence at k consecutive A wins (default 2); max-passes ceiling (default 15). Refuses dirty working tree (real run only).
- **Audit trail**: 6 record types in `history.jsonl` — candidate / outcome / decision / critique / patch_proposal / synthesis. Every LLM call's raw text persisted. 5-pass run writes ~50 records, all replayable.

### Polish (T7–T8)

- HANDOFF.md §2 rewritten with three execution modes: 2a `tournament autoreason` (recommended), 2b `run-round --baseline-only` (LLM-unavailable fallback), 2c hand-crafted `propose / run / promote` (single-experiment).
- `research_loop/tools/autoreason_smoke.py` — 30-second / ~$0.05 real-LLM round-trip pre-flight that operators run before launching multi-hour autoreason runs. Verifies API key, Critic shape, both diffs pass `git apply --check`, working tree clean.

## Tests

**151 / 151 tests pass on CPU**, no real GPU and no real LLM call in the suite. New tests this PR:

| File | Cases | What it covers |
|---|---:|---|
| `student_finetune/tests/test_metrics_progress_write.py` | 5 | atomic write contract, schema completeness, tmp-file cleanup |
| `research_loop/tests/test_budget.py` | 6 | timeout kill within tolerance, partial metrics recovery, decide() rejection |
| `research_loop/tests/test_patch_applicator.py` | 11 | apply/revert roundtrip, V1 refusal, malformed diffs, dirty-tree refusal |
| `research_loop/tests/test_agent_client.py` | 8 | API key resolution, request shape, fresh-agent invariant, cache_control |
| `research_loop/tests/test_agents.py` | 12 | Critique parsing, Author B prompt enumerates V1 paths, Synthesizer uses anonymized X/Y, synthesizer leaks no metrics |
| `research_loop/tests/test_autoreason_loop.py` | 6 | k=2 convergence, max-passes nonzero exit, full audit trail, dry-run, dirty-tree refusal |

## Project decisions baked in

- **No LLM judges** — objective ML metrics through `promote.decide()`. Justified by autoreason paper §6 (code domain uses test cases, not Borda).
- **Single Sonnet 4.6 for all three roles** — fast enough, capable enough; per-role model tier deferred.
- **Synthesizer sees only patches, no metric history** — project decision 2026-04-25, SPEC-AUTOREASON.md §Open questions resolved.
- **Time budget mandatory in production** — autoreason without timeout could chew 50h on one hallucinated patch.
- **V2-only safety enforced twice** — LLM system prompt forbids V1 edits AND patch applicator rejects V1 paths before `git apply`.

## Cost ceiling

- Default 15 passes × 5 LLM calls (Critic + Author + Synthesizer + 2 unused) = 75 LLM calls per autoreason run
- At Sonnet 4.6 with prompt caching on system blocks: ≤ ~$5 / run
- One pre-flight smoke before launching: ~$0.05

## Outstanding for the operator

- [ ] Run `research_loop/tools/autoreason_smoke.py` once with a real `ANTHROPIC_API_KEY` and record the output in HANDOFF.md (T8 hands-on verification — this PR's dev environment has Claude Code OAuth but no raw API key).
- [ ] Launch the first production `tournament autoreason --target student_v2` (or `dino_v2`) on `experiment/v2-baseline-tournament-2026-04-25`-style branch.

## Test plan

- [x] All 151 unit + integration tests pass on CPU
- [x] Tournament CLI smoke: `tournament autoreason --help` shows all 6 flags
- [x] V1 default behavior preserved (additive trainer edits only — `MAX_TRAINING_SECONDS=0` etc. unchanged)
- [ ] Real-LLM smoke (T8 — pending operator with API access)
- [ ] First production autoreason run (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)