### PR TITLE
feat: USE_PRODUCTNESS_CLS toggle via CLI + env var, default OFF

### DIFF
--- a/dino_finetune/train_dino_v2.py
+++ b/dino_finetune/train_dino_v2.py
@@ -102,7 +102,12 @@ BASE_ANCHOR_WEIGHT = 0.1
 # learn productness so its embedding space is product-aware before distillation.
 # Target derivation is cleaner here than student: label == NEGATIVE_LABEL → 0.0,
 # anything else (real class id or COMMODITY_LABEL) → 1.0. No path-string match.
-USE_PRODUCTNESS_CLS = True
+# OFF by default per algo-lead direction (2026-04-26). Opt-in via CLI
+# `--productness` or env `USE_PRODUCTNESS_CLS=1`.
+USE_PRODUCTNESS_CLS = (
+    os.environ.get("USE_PRODUCTNESS_CLS", "0").lower()
+    in ("1", "true", "yes", "on")
+)
 PRODUCTNESS_CLS_WEIGHT = 0.02
 PRODUCTNESS_HEAD_HIDDEN = 256
 PRODUCTNESS_LABEL_SMOOTHING_POS = 0.05
@@ -994,10 +999,20 @@ if __name__ == "__main__":
         "--max-epochs", type=int, default=None,
         help=f"Override module-level EPOCHS (default {EPOCHS})",
     )
+    parser.add_argument(
+        "--productness",
+        action=argparse.BooleanOptionalAction, default=None,
+        help="Toggle productness CLS branch (use --productness or --no-productness). "
+             "Default reads USE_PRODUCTNESS_CLS env var (default ON). "
+             "CLI flag overrides env.",
+    )
     args = parser.parse_args()
     if args.max_epochs is not None:
         EPOCHS = args.max_epochs  # noqa: F811 — module-level rebind for tournament use
         logger.info(f"EPOCHS overridden via CLI: {EPOCHS}")
+    if args.productness is not None:
+        USE_PRODUCTNESS_CLS = args.productness  # noqa: F811
+        logger.info(f"USE_PRODUCTNESS_CLS overridden via CLI: {USE_PRODUCTNESS_CLS}")
 
     try:
         main()

--- a/research_loop/promote.py
+++ b/research_loop/promote.py
@@ -144,16 +144,20 @@ def is_deployable(result: CandidateResult) -> DeployVerdict:
 
     Independent of the tournament `decide()` — a candidate can win promotion
     over A (it's the new best) yet still not be shippable in absolute terms.
+
+    Productness thresholds are *conditional*: if the candidate exposes the
+    field, it must meet the threshold; if absent (model trained with
+    USE_PRODUCTNESS_CLS=False), the check is skipped. This lets the same
+    deploy gate serve both productness-enabled and productness-disabled
+    pipelines without requiring two parallel codepaths.
     """
     failures: list[str] = []
     if result.combined < DEPLOY_MIN_COMBINED:
         failures.append(
             f"combined={result.combined:.4f} < {DEPLOY_MIN_COMBINED}"
         )
-    if result.productness_pos_acc is None or result.productness_pos_acc < DEPLOY_MIN_PRODUCTNESS_POS_ACC:
-        actual = "missing" if result.productness_pos_acc is None else f"{result.productness_pos_acc:.4f}"
-        failures.append(f"productness_pos_acc={actual} < {DEPLOY_MIN_PRODUCTNESS_POS_ACC}")
-    if result.productness_neg_acc is None or result.productness_neg_acc < DEPLOY_MIN_PRODUCTNESS_NEG_ACC:
-        actual = "missing" if result.productness_neg_acc is None else f"{result.productness_neg_acc:.4f}"
-        failures.append(f"productness_neg_acc={actual} < {DEPLOY_MIN_PRODUCTNESS_NEG_ACC}")
+    if result.productness_pos_acc is not None and result.productness_pos_acc < DEPLOY_MIN_PRODUCTNESS_POS_ACC:
+        failures.append(f"productness_pos_acc={result.productness_pos_acc:.4f} < {DEPLOY_MIN_PRODUCTNESS_POS_ACC}")
+    if result.productness_neg_acc is not None and result.productness_neg_acc < DEPLOY_MIN_PRODUCTNESS_NEG_ACC:
+        failures.append(f"productness_neg_acc={result.productness_neg_acc:.4f} < {DEPLOY_MIN_PRODUCTNESS_NEG_ACC}")
     return DeployVerdict(deployable=not failures, reasons=tuple(failures))

--- a/research_loop/tests/test_promote_guardrails.py
+++ b/research_loop/tests/test_promote_guardrails.py
@@ -226,13 +226,26 @@ def test_is_deployable_pos_acc_too_low():
     assert any("pos_acc" in reason for reason in verdict.reasons)
 
 
-def test_is_deployable_missing_productness_fails():
-    """A V1-style result without productness cannot be deployed under V2 rules."""
-    r = CandidateResult("v1", "A", combined=0.88, recall_1=0.92, mean_cosine=0.84)
+def test_is_deployable_missing_productness_passes_when_combined_meets_bar():
+    """Productness checks are *conditional*: a model trained without the
+    CLS branch (USE_PRODUCTNESS_CLS=False) has no productness fields and
+    must still be deployable when combined clears the bar. The deploy gate
+    cannot block a productness-disabled pipeline solely for missing fields."""
+    r = CandidateResult("no-cls", "A", combined=0.88, recall_1=0.92, mean_cosine=0.84)
+    verdict = is_deployable(r)
+    assert verdict.deployable is True
+    assert verdict.reasons == ()
+
+
+def test_is_deployable_missing_productness_still_fails_on_combined():
+    """Sanity: if combined is below threshold, the gate still blocks even
+    without productness fields."""
+    r = CandidateResult("no-cls-low", "A", combined=0.50, recall_1=0.50, mean_cosine=0.40)
     verdict = is_deployable(r)
     assert verdict.deployable is False
-    assert any("pos_acc" in reason for reason in verdict.reasons)
-    assert any("neg_acc" in reason for reason in verdict.reasons)
+    assert any("combined" in reason for reason in verdict.reasons)
+    # No productness reasons since fields were absent
+    assert not any("pos_acc" in reason or "neg_acc" in reason for reason in verdict.reasons)
 
 
 def test_is_deployable_collects_all_failures():

--- a/student_finetune/train_v2.py
+++ b/student_finetune/train_v2.py
@@ -30,6 +30,7 @@ Usage:
 """
 
 import argparse
+import os
 import json
 import random
 import sys
@@ -116,10 +117,17 @@ COMMODITY_MAX_SAMPLES = 20000       # Cap commodity (full 30k overwhelms product
 # V2 feature flags
 USE_STRONG_AUG = True
 
-# V2 productness CLS branch (issue #5) — ON by default. Per project decision
-# (2026-04-25), all future models must ship with productness; the flag is kept
-# only as a debugging escape hatch / for proving the V1 path is unaffected.
-USE_PRODUCTNESS_CLS = True
+# V2 productness CLS branch (issue #5) — OFF by default per algo-lead direction
+# (2026-04-26): productness is moving out of the production pipeline.
+# Override via:
+#   1. CLI:   `python train_v2.py --productness`     (opt-in)
+#   2. env:   `USE_PRODUCTNESS_CLS=1` (also accepts "true", "yes", "on")
+# Resolution order: CLI > env > module default. The CLI flag rebinds this
+# constant after argparse so the rest of the file can keep reading it directly.
+USE_PRODUCTNESS_CLS = (
+    os.environ.get("USE_PRODUCTNESS_CLS", "0").lower()
+    in ("1", "true", "yes", "on")
+)
 PRODUCTNESS_CLS_WEIGHT = 0.02
 PRODUCTNESS_HEAD_HIDDEN = 256
 PRODUCTNESS_VAL_HOLDOUT_PATH = (
@@ -1078,7 +1086,16 @@ if __name__ == "__main__":
     parser.add_argument("--patience", type=int, default=7)
     parser.add_argument("--swa-epochs", type=int, default=3)
     parser.add_argument("--resume", action="store_true")
+    parser.add_argument(
+        "--productness",
+        action=argparse.BooleanOptionalAction, default=None,
+        help="Toggle productness CLS branch (use --productness or --no-productness). "
+             "Default reads USE_PRODUCTNESS_CLS env var (default ON). "
+             "CLI flag overrides env.",
+    )
     args = parser.parse_args()
+    if args.productness is not None:
+        USE_PRODUCTNESS_CLS = args.productness  # noqa: F811 — module-level rebind
 
     try:
         main(


### PR DESCRIPTION
## Why

Algorithm lead is moving productness CLS out of the production pipeline (reversal of the 2026-04-25 "mandatory" decision). This PR:

1. Makes the toggle a **CLI flag + env var** instead of a module constant requiring source edits
2. **Flips the default**: productness is now opt-in, default OFF

## How

Resolution order: \`--productness/--no-productness\` > \`USE_PRODUCTNESS_CLS\` env var > module default (**False**).

\`\`\`bash
python student_finetune/train_v2.py                       # default — productness OFF
python student_finetune/train_v2.py --productness         # opt-in
USE_PRODUCTNESS_CLS=1 python student_finetune/train_v2.py # env-only opt-in
python dino_finetune/train_dino_v2.py --productness       # same flag on dino
\`\`\`

When productness is disabled (the new default), the trainer:
- uses \`LCNet\` / DINOv3 base (not the \`*Productness*\` variants)
- skips productness optimizer params, BCE+focal loss, val eval, logging
- emits \`Outcome\` records with \`productness_*\` fields absent

## Deploy gate update

\`promote.is_deployable()\` previously **hard-required** \`productness_pos_acc\` and \`productness_neg_acc\` — without them, the gate always returned not-deployable. With productness now default-OFF, that would block every default training run from shipping. Fix: productness thresholds are now **conditional** — present → must meet bar; absent → skip. \`combined ≥ DEPLOY_MIN_COMBINED\` remains hard.

## Tests

- **233 tests pass** (research_loop + student_finetune productness suite)
- Replaced \`test_is_deployable_missing_productness_fails\` with two tests:
  - \`test_is_deployable_missing_productness_passes_when_combined_meets_bar\` — new contract
  - \`test_is_deployable_missing_productness_still_fails_on_combined\` — sanity
- CLI help verified clean (no duplicate flag), env var resolution verified all paths

## Files

| File | Change |
|---|---|
| \`student_finetune/train_v2.py\` | env var read for default (now \"0\"); CLI flag with rebind after argparse |
| \`dino_finetune/train_dino_v2.py\` | same |
| \`research_loop/promote.py\` | \`is_deployable\` productness checks conditional |
| \`research_loop/tests/test_promote_guardrails.py\` | flipped + added test for new contract |

## Project-memory note

\`MEMORY.md\` → \`project_productness_mandatory.md\` flipped to "opt-in, default OFF" (this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)