### PR TITLE
feat: auto-scale BATCH_SIZE by VRAM (eliminates per-GPU tuning)

### DIFF
--- a/dino_finetune/train_dino_v2.py
+++ b/dino_finetune/train_dino_v2.py
@@ -69,8 +69,23 @@ LORA_DROPOUT = 0.05
 LORA_TARGET_MODULES = ["q_proj", "v_proj"]
 
 # -- Optimization --
-BATCH_SIZE = 8
-GRADIENT_ACCUMULATION_STEPS = 16
+def _auto_batch(default_at_24gb: int) -> int:
+    """Scale BATCH_SIZE linearly with available VRAM (baseline = 24GB / RTX 4090).
+
+    Override via env var: `BATCH_SIZE=64 python train_dino_v2.py`.
+    Falls back to baseline default on CPU-only systems.
+    """
+    import torch as _torch
+    if not _torch.cuda.is_available():
+        return default_at_24gb
+    vram_gb = _torch.cuda.get_device_properties(0).total_memory / (1024 ** 3)
+    return max(1, int(default_at_24gb * (vram_gb / 24.0)))
+
+
+# Effective batch = BATCH_SIZE * GRADIENT_ACCUMULATION_STEPS = 128 (preserved
+# across hardware tiers). Override either via env vars to tune independently.
+BATCH_SIZE = int(os.environ.get("BATCH_SIZE") or _auto_batch(8))
+GRADIENT_ACCUMULATION_STEPS = int(os.environ.get("GRADIENT_ACCUMULATION_STEPS") or max(1, 128 // BATCH_SIZE))
 LR = 5e-4
 WEIGHT_DECAY = 0.01
 WARMUP_RATIO = 0.2

--- a/student_finetune/train_v2.py
+++ b/student_finetune/train_v2.py
@@ -75,8 +75,24 @@ from train import (
 # V2 CONFIGURATION
 # ============================================================
 MODEL_NAME = "hf-hub:timm/lcnet_050.ra2_in1k"
-BATCH_SIZE = 64
-ARCFACE_BATCH_SIZE = 256
+
+
+def _auto_batch(default_at_24gb: int) -> int:
+    """Scale batch size linearly with available VRAM, baseline = 24GB (RTX 4090).
+
+    Override via env var (e.g. `BATCH_SIZE=128 python train_v2.py`).
+    Falls back to baseline default on CPU-only systems.
+    """
+    import os
+    import torch
+    if not torch.cuda.is_available():
+        return default_at_24gb
+    vram_gb = torch.cuda.get_device_properties(0).total_memory / (1024 ** 3)
+    return max(1, int(default_at_24gb * (vram_gb / 24.0)))
+
+
+BATCH_SIZE = int(os.environ.get("BATCH_SIZE") or _auto_batch(64))
+ARCFACE_BATCH_SIZE = int(os.environ.get("ARCFACE_BATCH_SIZE") or _auto_batch(256))
 LR = 8e-3
 WEIGHT_DECAY = 1e-3
 NUM_WORKERS = 16


### PR DESCRIPTION
## Why

Moving the codebase between dev rig (RTX 4090 24GB) and production GPUs (H100 96GB / L40S 48GB) currently requires editing \`BATCH_SIZE\` and \`GRADIENT_ACCUMULATION_STEPS\` in two trainer files. This auto-scales them at startup.

## How

Each trainer reads \`torch.cuda.get_device_properties(0).total_memory\` at module load and scales batch size linearly relative to the 24GB baseline. \`GRADIENT_ACCUMULATION_STEPS\` for dino auto-adjusts so **effective batch stays ~128** — training dynamics (LR / warmup / scheduler) preserved, only wallclock changes.

| GPU | dino \`BATCH_SIZE\` / \`GRAD_ACCUM\` (effective) | student \`BATCH_SIZE\` / \`ARCFACE_BATCH\` |
|---|---|---|
| 4090 (24GB) | 8 / 16 (128) | 64 / 256 |
| A6000 / L40S (48GB) | 16 / 8 (128) | 128 / 512 |
| H100-80 | 26 / 4 (104) | 213 / 853 |
| H100-96 / A100-96 | **32 / 4 (128)** | **256 / 1024** |

## Override always available via env var

\`\`\`bash
BATCH_SIZE=64 python student_finetune/train_v2.py
BATCH_SIZE=24 GRADIENT_ACCUMULATION_STEPS=8 python dino_finetune/train_dino_v2.py
ARCFACE_BATCH_SIZE=512 python student_finetune/train_v2.py
\`\`\`

Resolution order: env var > auto-scaled default. CPU-only systems fall back to the 24GB-baseline numbers.

## Implementation

- ~10-line \`_auto_batch(default_at_24gb)\` helper inlined into each trainer
- No shared module added — trainers are otherwise independent
- 206 research_loop tests still pass

## Files

| File | Change |
|---|---|
| \`student_finetune/train_v2.py\` | \`_auto_batch\`; \`BATCH_SIZE\` + \`ARCFACE_BATCH_SIZE\` env-var-overridable auto-scaled defaults |
| \`dino_finetune/train_dino_v2.py\` | same; \`GRADIENT_ACCUMULATION_STEPS\` derived to preserve effective=128 |

## Test plan

- [x] Math verified for 4 GPU tiers (24/48/80/96 GB)
- [x] 206 unit + integration tests pass
- [x] Existing 4090 setup → identical numbers (8/16, 64/256)
- [ ] Real run on 96GB GPU (operator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)